### PR TITLE
feat(cli): add --remove and --reset commands for template removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,42 @@ npx cursor-templates web-frontend --ide=codex
 npx cursor-templates web-frontend --ide=cursor --ide=codex
 ```
 
+### Remove Specific Templates
+
+Remove templates you no longer need while keeping shared rules and other templates:
+
+```bash
+# Remove a single template
+npx cursor-templates --remove web-frontend
+
+# Remove multiple templates
+npx cursor-templates --remove web-frontend web-backend
+
+# Remove from specific IDE only
+npx cursor-templates --remove web-frontend --ide=cursor
+
+# Skip confirmation prompt
+npx cursor-templates --remove web-frontend --yes
+```
+
+### Reset (Remove Everything)
+
+Remove all installed content (shared rules, templates, generated files):
+
+```bash
+# Reset all installed content
+npx cursor-templates --reset
+
+# Reset for specific IDE only
+npx cursor-templates --reset --ide=cursor
+
+# Skip confirmation prompt
+npx cursor-templates --reset --yes
+
+# Force remove modified files
+npx cursor-templates --reset --force
+```
+
 ### CLI Options
 
 | Option | Description |
@@ -100,7 +136,10 @@ npx cursor-templates web-frontend --ide=cursor --ide=codex
 | `--ide=<name>` | Target IDE: `cursor`, `claude`, or `codex` (can be used multiple times) |
 | `--list`, `-l` | List all available templates |
 | `--dry-run` | Preview changes without writing files |
-| `--force`, `-f` | Overwrite existing files |
+| `--force`, `-f` | Overwrite/remove even if files were modified |
+| `--remove` | Remove specified templates |
+| `--reset` | Remove ALL installed content |
+| `--yes`, `-y` | Skip confirmation prompt (for `--remove` and `--reset`) |
 | `--help`, `-h` | Show help message |
 
 ## Available Templates

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,4 +2,7 @@
 
 import { run } from '../src/index.js';
 
-run(process.argv.slice(2));
+run(process.argv.slice(2)).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Add two new commands for managing installed templates:

- --remove <templates>: Remove specific templates while preserving shared rules and other templates
- --reset: Remove all installed content (shared rules, templates, and generated files)

Features:
- Dry-run support (--dry-run) to preview changes
- IDE-specific removal (--ide flag support)
- Confirmation prompt with --yes/-y to skip
- Safe defaults: modified files are preserved unless --force is used
- Detection of modified files vs original template content