### PR TITLE
ci: add auto-merge workflow for release PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,30 @@
+name: Auto-merge Release PRs
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    steps:
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash
+
+      - name: Auto-approve
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that automatically merges release-please PRs.

## How it works

- Triggers on PR events (labeled, opened, synchronize, reopened)
- Checks for `autorelease: pending` label (applied by release-please)
- Enables auto-merge with squash strategy
- Auto-approves the PR
- PR merges automatically once CI passes

## Benefits

- Streamlines the release process
- No manual intervention needed for releases
- Releases happen automatically after CI passes

## Test plan

- [ ] Verify workflow triggers on release-please PRs
- [ ] Verify auto-merge enables correctly
- [ ] Verify PR merges after CI passes