### PR TITLE
fix(docs): replace angle brackets breaking npm README rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ AI coding assistant templates for Cursor IDE, Claude Code, and GitHub Copilot. P
 No installation required. Run directly with `npx`:
 
 ```bash
-npx agentic-team-templates <template-name>
+npx agentic-team-templates [template-name]
 ```
 
 Or install globally:
 
 ```bash
 npm install -g agentic-team-templates
-agentic-team-templates <template-name>
+agentic-team-templates [template-name]
 ```
 
 ## How to Use
@@ -133,7 +133,7 @@ npx agentic-team-templates --reset --force
 
 | Option | Description |
 |--------|-------------|
-| `--ide=<name>` | Target IDE: `cursor`, `claude`, or `codex` (can be used multiple times) |
+| `--ide=[name]` | Target IDE: `cursor`, `claude`, or `codex` (can be used multiple times) |
 | `--list`, `-l` | List all available templates |
 | `--dry-run` | Preview changes without writing files |
 | `--force`, `-f` | Overwrite/remove even if files were modified |
@@ -278,7 +278,7 @@ If you're getting errors for options that should exist (like `--reset`), you may
 
 ```bash
 # Force latest version (recommended)
-npx agentic-team-templates@latest <command>
+npx agentic-team-templates@latest [command]
 
 # Clear npx cache
 npx clear-npx-cache


### PR DESCRIPTION
## Summary

- Fixes README not rendering on npm package page since v0.8.0
- Angle bracket placeholders (`<template-name>`, `<command>`, `<name>`) were being interpreted as unclosed HTML tags by npm's markdown parser
- Replaced with square bracket syntax which is equally clear and doesn't break parsing

## Problem

After the v0.8.0 release, the README completely failed to render on the npm package page. The npm markdown parser was interpreting placeholder syntax like `<template-name>` as HTML elements, causing a parsing failure that prevented any content from displaying.

## Changes

| Before | After |
|--------|-------|
| `<template-name>` | `[template-name]` |
| `<command>` | `[command]` |
| `<name>` | `[name]` |

4 occurrences updated across the README.

## Test Plan

- [ ] Verify README renders correctly on npm after patch release
- [ ] Confirm placeholder syntax is still clear and readable