### PR TITLE
feat(ci): add auto-merge workflow for release PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    if: "${{ contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3


### PR DESCRIPTION
## Summary

- Adds automatic merge workflow for release-please PRs
- Automatically approves and enables auto-merge when PRs have the `autorelease: pending` label

## Changes

- New workflow `.github/workflows/auto-merge.yml` that:
  - Triggers on PR labeled/opened/synchronize/reopened events
  - Checks for `autorelease: pending` label (added by release-please)
  - Enables squash auto-merge via `peter-evans/enable-pull-request-automerge@v3`
  - Auto-approves via `hmarr/auto-approve-action@v4`

## Why

Reduces manual overhead for release PRs. When release-please creates a release PR, it will automatically be approved and merged once CI passes.

## Test Plan

- [ ] Verify workflow passes GitHub Actions validation
- [ ] Test with next release-please PR