### PR TITLE
fix(ci): enable auto-merge directly in release-please workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,14 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     if: "${{ contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
+      # Generate GitHub App token for auto-approve (can't use GITHUB_TOKEN to approve own PRs)
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
 
       - name: Auto-approve
         uses: hmarr/auto-approve-action@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,15 +24,26 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # Enable auto-merge on release PRs when they are created/updated
-      - name: Enable auto-merge for release PR
+      # Generate GitHub App token for auto-approve (can't use GITHUB_TOKEN to approve own PRs)
+      - name: Generate GitHub App Token
+        id: app-token
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # Auto-approve and enable auto-merge on release PRs
+      - name: Auto-approve and merge release PR
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          # Find the release PR with autorelease label and enable auto-merge
+          # Find the release PR with autorelease label
           PR_NUMBER=$(gh pr list --label "autorelease: pending" --json number --jq '.[0].number')
           if [ -n "$PR_NUMBER" ]; then
+            echo "Approving PR #$PR_NUMBER"
+            gh pr review "$PR_NUMBER" --approve
             echo "Enabling auto-merge for PR #$PR_NUMBER"
             gh pr merge "$PR_NUMBER" --auto --squash
           fi


### PR DESCRIPTION
## Problem

The standalone auto-merge workflow never triggers for release-please PRs because GitHub doesn't run workflows on PRs created by `GITHUB_TOKEN` (to prevent infinite loops).

## Solution

Add auto-merge enablement directly to the release-please workflow itself. When release-please creates or updates a PR, the same workflow will enable auto-merge on that PR. Use GitHub App token for auto-approval.

## Changes

- Added auto-merge step to `release-please.yml` that runs when `prs_created == 'true'`
- Generate GitHub App token and use for `gh pr review --approve` and `gh pr merge --auto --squash`
- Updated `auto-merge.yml` to use GitHub App token as well

## BREAKING CHANGE: CLI command name

**Bin command renamed from `cursor-templates` to `agentic-team-templates`.**

| Before | After |
|--------|-------|
| `cursor-templates web-frontend` | `agentic-team-templates web-frontend` |

**Impact:**
- **Global installs:** If you have `npm install -g agentic-team-templates` and run the CLI by name, use `agentic-team-templates` instead of `cursor-templates`.
- **npx users:** No change — `npx agentic-team-templates` was already correct and remains so.
- **Scripts/aliases:** Update any references from `cursor-templates` to `agentic-team-templates`.

Documented in README (Upgrading section) and CHANGELOG (Unreleased).

## Test Plan

- [ ] Merge this PR
- [ ] Verify next release PR is auto-approved and auto-merged
- [ ] Confirm CHANGELOG and README document the breaking change for the release