### PR TITLE
feat(templates): add java-expert template

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ npx agentic-team-templates --reset --force
 | `documentation` | Technical documentation standards (READMEs, API docs, ADRs, code comments) |
 | `fullstack` | Full-stack web applications (Next.js, Nuxt, SvelteKit, Remix) |
 | `golang-expert` | Principal-level Go engineering (concurrency, stdlib, production patterns, testing) |
+| `java-expert` | Principal-level Java engineering (JVM, Spring Boot, concurrency, JPA, testing) |
 | `javascript-expert` | Principal-level JavaScript engineering across Node.js, React, vanilla JS, and testing |
 | `ml-ai` | Machine learning and AI systems (model development, deployment, monitoring) |
 | `mobile` | Mobile applications (React Native, Flutter, native iOS/Android) |

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,10 @@ const TEMPLATES = {
     description: 'Principal-level Go engineering (concurrency, stdlib, production patterns, testing)',
     rules: ['concurrency.md', 'error-handling.md', 'interfaces-and-types.md', 'overview.md', 'performance.md', 'production-patterns.md', 'stdlib-and-tooling.md', 'testing.md']
   },
+  'java-expert': {
+    description: 'Principal-level Java engineering (JVM, Spring Boot, concurrency, JPA, testing)',
+    rules: ['concurrency.md', 'error-handling.md', 'modern-java.md', 'overview.md', 'performance.md', 'persistence.md', 'spring-boot.md', 'testing.md', 'tooling.md']
+  },
   'javascript-expert': {
     description: 'Principal-level JavaScript engineering across Node.js, React, vanilla JS, and testing',
     rules: ['language-deep-dive.md', 'node-patterns.md', 'overview.md', 'performance.md', 'react-patterns.md', 'testing.md', 'tooling.md']

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -80,6 +80,7 @@ describe('Constants', () => {
         'documentation',
         'fullstack',
         'golang-expert',
+        'java-expert',
         'javascript-expert',
         'ml-ai',
         'mobile',

--- a/templates/java-expert/.cursorrules/concurrency.md
+++ b/templates/java-expert/.cursorrules/concurrency.md
@@ -1,0 +1,209 @@
+# Java Concurrency
+
+The Java Memory Model is the law. Every concurrent decision must respect it.
+
+## Virtual Threads (Java 21+)
+
+The default for I/O-bound work. Platform threads for CPU-bound work.
+
+```java
+// Virtual threads for I/O concurrency
+try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+    var futures = tasks.stream()
+        .map(task -> executor.submit(() -> process(task)))
+        .toList();
+
+    var results = futures.stream()
+        .map(f -> {
+            try { return f.get(30, TimeUnit.SECONDS); }
+            catch (TimeoutException e) { throw new ProcessingTimeoutException(e); }
+            catch (ExecutionException e) { throw new ProcessingException(e.getCause()); }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new ProcessingException(e);
+            }
+        })
+        .toList();
+}
+```
+
+### Virtual Thread Rules
+
+- Don't pool virtual threads — they're cheap to create
+- Don't use `synchronized` for I/O operations — use `ReentrantLock`
+- Don't pin virtual threads to carrier threads (`synchronized` blocks pin)
+- Don't use `ThreadLocal` for request-scoped data — use `ScopedValue` (preview)
+
+```java
+// Bad: synchronized pins virtual thread to carrier
+synchronized (lock) {
+    database.query(sql); // I/O while pinned — wastes carrier thread
+}
+
+// Good: ReentrantLock doesn't pin
+private final ReentrantLock lock = new ReentrantLock();
+
+lock.lock();
+try {
+    database.query(sql); // Virtual thread can unmount during I/O
+} finally {
+    lock.unlock();
+}
+```
+
+## Structured Concurrency (Preview)
+
+```java
+// All subtasks succeed or all are cancelled — no leaked threads
+try (var scope = new StructuredTaskScope.ShutdownOnFailure()) {
+    Subtask<User> userTask = scope.fork(() -> userService.findById(userId));
+    Subtask<List<Order>> ordersTask = scope.fork(() -> orderService.findByUser(userId));
+
+    scope.join();           // Wait for all
+    scope.throwIfFailed();  // Propagate first failure
+
+    return new Dashboard(userTask.get(), ordersTask.get());
+}
+```
+
+## CompletableFuture
+
+```java
+// Async pipeline with proper error handling
+public CompletableFuture<OrderResult> processOrderAsync(CreateOrderRequest request) {
+    return validateAsync(request)
+        .thenCompose(this::checkInventoryAsync)
+        .thenCompose(this::createOrderAsync)
+        .thenApply(OrderResult::success)
+        .exceptionally(ex -> {
+            log.error("Order processing failed", ex);
+            return OrderResult.failure(ex.getMessage());
+        });
+}
+
+// Combine independent operations
+public CompletableFuture<Dashboard> loadDashboard(UUID userId) {
+    var userFuture = CompletableFuture.supplyAsync(() -> userService.findById(userId));
+    var ordersFuture = CompletableFuture.supplyAsync(() -> orderService.recent(userId));
+    var statsFuture = CompletableFuture.supplyAsync(() -> statsService.forUser(userId));
+
+    return CompletableFuture.allOf(userFuture, ordersFuture, statsFuture)
+        .thenApply(v -> new Dashboard(
+            userFuture.join(),
+            ordersFuture.join(),
+            statsFuture.join()));
+}
+```
+
+## Thread Safety Patterns
+
+### Immutability (Preferred)
+
+```java
+// Immutable objects are inherently thread-safe
+public record UserSnapshot(UUID id, String name, Instant capturedAt) {}
+
+// Unmodifiable collections
+private final List<String> allowedRoles = List.of("USER", "ADMIN", "MODERATOR");
+```
+
+### Atomic Operations
+
+```java
+private final AtomicLong requestCounter = new AtomicLong();
+private final AtomicReference<Config> currentConfig = new AtomicReference<>(Config.defaults());
+
+public void handleRequest() {
+    requestCounter.incrementAndGet();
+}
+
+public void updateConfig(Config newConfig) {
+    currentConfig.set(newConfig);
+}
+```
+
+### ConcurrentHashMap
+
+```java
+// Thread-safe map with atomic compute operations
+private final ConcurrentHashMap<String, AtomicLong> counters = new ConcurrentHashMap<>();
+
+public void increment(String key) {
+    counters.computeIfAbsent(key, k -> new AtomicLong()).incrementAndGet();
+}
+
+// Never iterate and modify — use compute/merge operations
+counters.merge(key, new AtomicLong(1), (existing, value) -> {
+    existing.incrementAndGet();
+    return existing;
+});
+```
+
+### Bounded Queues
+
+```java
+// Backpressure via bounded queue
+private final BlockingQueue<Event> eventQueue = new LinkedBlockingQueue<>(10_000);
+
+public boolean publish(Event event) {
+    return eventQueue.offer(event); // Returns false if full — handle backpressure
+}
+
+public void consume() {
+    while (!Thread.currentThread().isInterrupted()) {
+        try {
+            Event event = eventQueue.poll(1, TimeUnit.SECONDS);
+            if (event != null) process(event);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            break;
+        }
+    }
+}
+```
+
+## Interrupt Handling
+
+```java
+// Always restore interrupt status
+public void processItems(List<Item> items) {
+    for (var item : items) {
+        if (Thread.currentThread().isInterrupted()) {
+            log.warn("Processing interrupted, {} items remaining", items.size());
+            break;
+        }
+        process(item);
+    }
+}
+
+// In catch blocks
+try {
+    Thread.sleep(Duration.ofSeconds(5));
+} catch (InterruptedException e) {
+    Thread.currentThread().interrupt(); // Restore flag
+    throw new RuntimeException("Operation interrupted", e);
+}
+```
+
+## Anti-Patterns
+
+```java
+// Never: double-checked locking without volatile (pre-Java 5 bug, but still seen)
+// Use: enum singleton, or lazy holder pattern, or just @Singleton
+
+// Never: synchronized on non-final fields
+private Object lock = new Object(); // Can be reassigned!
+synchronized (lock) { } // Different threads may lock different objects
+// Use: private final Object lock = new Object();
+
+// Never: Thread.stop() or Thread.suspend()
+// Use: cooperative interruption via Thread.interrupt()
+
+// Never: busy-wait
+while (!ready) { } // Burns CPU
+// Use: CountDownLatch, Semaphore, or BlockingQueue
+
+// Never: shared mutable state without synchronization
+private int counter; // Multiple threads read/write without coordination
+// Use: AtomicInteger, or synchronize access
+```

--- a/templates/java-expert/.cursorrules/error-handling.md
+++ b/templates/java-expert/.cursorrules/error-handling.md
@@ -1,0 +1,205 @@
+# Java Error Handling
+
+Exceptions for exceptional conditions. Validation at boundaries. Never swallow errors.
+
+## Exception Hierarchy
+
+```java
+// Application exception base — unchecked
+public abstract class ApplicationException extends RuntimeException {
+    private final String errorCode;
+
+    protected ApplicationException(String errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    protected ApplicationException(String errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() { return errorCode; }
+}
+
+// Specific exceptions
+public class NotFoundException extends ApplicationException {
+    public NotFoundException(String entity, Object id) {
+        super("NOT_FOUND", "%s with id '%s' not found".formatted(entity, id));
+    }
+}
+
+public class ConflictException extends ApplicationException {
+    public ConflictException(String message) {
+        super("CONFLICT", message);
+    }
+}
+
+public class ValidationException extends ApplicationException {
+    private final Map<String, String> fieldErrors;
+
+    public ValidationException(Map<String, String> fieldErrors) {
+        super("VALIDATION_FAILED", "Validation failed");
+        this.fieldErrors = Map.copyOf(fieldErrors);
+    }
+
+    public Map<String, String> getFieldErrors() { return fieldErrors; }
+}
+```
+
+## Checked vs Unchecked
+
+```java
+// Checked exceptions: recoverable conditions at system boundaries
+// - IOException: file not found, network error — caller can retry or use fallback
+// - SQLException: database error — caller can retry with backoff
+
+// Unchecked exceptions: programming errors and business rule violations
+// - IllegalArgumentException: bad input
+// - NullPointerException: null where not expected
+// - NotFoundException: domain-level "not found"
+// - ValidationException: business rule violation
+
+// Rule: if the caller CAN and SHOULD handle it → checked
+//        if it's a bug or unrecoverable → unchecked
+```
+
+## Validation
+
+```java
+// Jakarta Bean Validation on DTOs
+public record CreateUserRequest(
+    @NotBlank(message = "Name is required")
+    @Size(min = 2, max = 200, message = "Name must be 2-200 characters")
+    String name,
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
+    String email,
+
+    @NotNull(message = "Role is required")
+    UserRole role
+) {}
+
+// Custom validator
+@Constraint(validatedBy = UniqueEmailValidator.class)
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniqueEmail {
+    String message() default "Email already registered";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}
+
+public class UniqueEmailValidator implements ConstraintValidator<UniqueEmail, String> {
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean isValid(String email, ConstraintValidatorContext context) {
+        return email == null || !userRepository.existsByEmail(email);
+    }
+}
+```
+
+## Guard Clauses
+
+```java
+public class OrderService {
+
+    public Order create(String customerId, List<OrderItem> items) {
+        // Fail fast with meaningful messages
+        Objects.requireNonNull(customerId, "customerId must not be null");
+        if (customerId.isBlank()) {
+            throw new IllegalArgumentException("customerId must not be blank");
+        }
+        if (items == null || items.isEmpty()) {
+            throw new IllegalArgumentException("Order must have at least one item");
+        }
+        if (items.size() > MAX_ITEMS) {
+            throw new ValidationException(Map.of(
+                "items", "Maximum %d items allowed".formatted(MAX_ITEMS)));
+        }
+
+        // Business logic follows clean preconditions
+        return Order.create(customerId, items);
+    }
+}
+```
+
+## Result Pattern (Alternative to Exceptions)
+
+```java
+// For operations where failure is expected, not exceptional
+public sealed interface Result<T> permits Result.Success, Result.Failure {
+
+    record Success<T>(T value) implements Result<T> {}
+    record Failure<T>(String code, String message) implements Result<T> {}
+
+    static <T> Result<T> success(T value) { return new Success<>(value); }
+    static <T> Result<T> failure(String code, String message) { return new Failure<>(code, message); }
+
+    default <U> U match(Function<T, U> onSuccess, BiFunction<String, String, U> onFailure) {
+        return switch (this) {
+            case Success<T> s -> onSuccess.apply(s.value());
+            case Failure<T> f -> onFailure.apply(f.code(), f.message());
+        };
+    }
+}
+
+// Usage
+public Result<User> register(RegisterRequest request) {
+    if (userRepository.existsByEmail(request.email())) {
+        return Result.failure("CONFLICT", "Email already registered");
+    }
+    var user = User.create(request.name(), request.email());
+    userRepository.save(user);
+    return Result.success(user);
+}
+```
+
+## Logging Exceptions
+
+```java
+// Log with context, not just the exception
+try {
+    return paymentService.charge(orderId, amount);
+} catch (PaymentException ex) {
+    log.error("Payment failed for order {} amount {}: {}",
+        orderId, amount, ex.getMessage(), ex);
+    throw new OrderProcessingException("Payment failed for order " + orderId, ex);
+}
+
+// Rules:
+// - Log at the point of handling, not at every rethrow
+// - Include business context (IDs, amounts, actions)
+// - Use structured logging parameters, not string concatenation
+// - Include the exception as the LAST parameter (for stack trace)
+// - Don't log AND throw at the same level (choose one)
+```
+
+## Anti-Patterns
+
+```java
+// Never: catching Exception or Throwable broadly
+try { doWork(); }
+catch (Exception e) { log.error("Error", e); }
+// Catches InterruptedException, NPE, and everything else — too broad
+
+// Never: empty catch blocks
+try { connection.close(); }
+catch (Exception e) { /* ignore */ }
+// At minimum: log.debug("Error closing connection", e);
+
+// Never: using exceptions for control flow
+try { return Integer.parseInt(input); }
+catch (NumberFormatException e) { return defaultValue; }
+// Use: input.matches("\\d+") or a tryParse utility
+
+// Never: wrapping without adding context
+catch (SQLException e) { throw new RuntimeException(e); }
+// Add context: throw new PersistenceException("Failed to save order " + orderId, e);
+
+// Never: losing the original exception
+catch (Exception e) { throw new RuntimeException("Something failed"); }
+// Always chain: throw new RuntimeException("Something failed", e);
+```

--- a/templates/java-expert/.cursorrules/modern-java.md
+++ b/templates/java-expert/.cursorrules/modern-java.md
@@ -1,0 +1,216 @@
+# Modern Java Language Features
+
+Java 21+ features used deliberately. Every feature exists to make code clearer — not to show off.
+
+## Records
+
+```java
+// Immutable data carriers — the default for DTOs, value objects, events
+public record CreateUserRequest(
+    @NotBlank String name,
+    @Email String email
+) {}
+
+public record Money(BigDecimal amount, Currency currency) {
+    // Compact constructor for validation
+    public Money {
+        if (amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Amount cannot be negative");
+        }
+        Objects.requireNonNull(currency, "Currency is required");
+    }
+}
+
+public record PageRequest(int page, int size) {
+    public PageRequest {
+        if (page < 0) throw new IllegalArgumentException("Page must be >= 0");
+        if (size < 1 || size > 100) throw new IllegalArgumentException("Size must be 1-100");
+    }
+
+    public int offset() {
+        return page * size;
+    }
+}
+```
+
+### When NOT to Use Records
+
+- JPA entities (need mutable state, no-arg constructor)
+- Spring beans (need proxying, lifecycle management)
+- Classes with complex behavior beyond data carrying
+
+## Sealed Classes
+
+```java
+// Exhaustive type hierarchies — the compiler enforces completeness
+public sealed interface PaymentResult permits PaymentSuccess, PaymentFailure, PaymentPending {
+}
+
+public record PaymentSuccess(String transactionId, Instant processedAt) implements PaymentResult {}
+public record PaymentFailure(String errorCode, String message) implements PaymentResult {}
+public record PaymentPending(String referenceId, Duration estimatedWait) implements PaymentResult {}
+
+// Exhaustive switch — compiler warns if a case is missing
+public String describeResult(PaymentResult result) {
+    return switch (result) {
+        case PaymentSuccess s -> "Paid: " + s.transactionId();
+        case PaymentFailure f -> "Failed: " + f.message();
+        case PaymentPending p -> "Pending: " + p.referenceId();
+    };
+}
+```
+
+## Pattern Matching
+
+```java
+// instanceof pattern matching — no more casting
+public String format(Object value) {
+    return switch (value) {
+        case Integer i when i < 0 -> "negative: " + i;
+        case Integer i -> "integer: " + i;
+        case String s when s.isEmpty() -> "empty string";
+        case String s -> "string: " + s;
+        case null -> "null";
+        default -> "unknown: " + value.getClass().getSimpleName();
+    };
+}
+
+// Record patterns (Java 21+)
+public double calculateArea(Shape shape) {
+    return switch (shape) {
+        case Circle(double radius) -> Math.PI * radius * radius;
+        case Rectangle(double w, double h) -> w * h;
+        case Triangle(double base, double height) -> 0.5 * base * height;
+    };
+}
+```
+
+## Text Blocks
+
+```java
+// Multi-line strings with proper indentation
+String query = """
+        SELECT u.id, u.name, u.email
+        FROM users u
+        WHERE u.active = true
+          AND u.created_at > :since
+        ORDER BY u.name
+        """;
+
+String json = """
+        {
+            "name": "%s",
+            "email": "%s"
+        }
+        """.formatted(name, email);
+```
+
+## Optional
+
+```java
+// Return type for "might not exist" — never for fields or parameters
+public Optional<User> findByEmail(String email) {
+    return Optional.ofNullable(userRepository.findByEmail(email));
+}
+
+// Good: chain operations
+public String getUserDisplayName(String email) {
+    return findByEmail(email)
+        .map(User::displayName)
+        .orElse("Unknown User");
+}
+
+// Good: throw with context
+public User getByEmail(String email) {
+    return findByEmail(email)
+        .orElseThrow(() -> new NotFoundException("User not found: " + email));
+}
+
+// Bad: Optional.get() without check — defeats the purpose
+user.get().getName(); // NoSuchElementException risk
+
+// Bad: Optional as method parameter
+public void process(Optional<String> name) { } // Use @Nullable instead
+
+// Bad: Optional as field
+private Optional<String> middleName; // Use @Nullable instead
+```
+
+## Collections
+
+```java
+// Immutable collections — the default
+var users = List.of("Alice", "Bob", "Charlie");
+var scores = Map.of("Alice", 95, "Bob", 87);
+var uniqueNames = Set.of("Alice", "Bob");
+
+// List.copyOf, Set.copyOf, Map.copyOf for defensive copies
+public List<User> getUsers() {
+    return List.copyOf(mutableUserList); // Defensive copy
+}
+
+// Collectors and Stream API
+var activeUsersByDepartment = users.stream()
+    .filter(User::isActive)
+    .collect(Collectors.groupingBy(
+        User::department,
+        Collectors.toUnmodifiableList()));
+
+// toList() shorthand (Java 16+)
+var names = users.stream()
+    .map(User::name)
+    .toList(); // Returns unmodifiable list
+```
+
+## Virtual Threads (Java 21+)
+
+```java
+// Virtual threads for I/O-bound concurrency — massive scalability
+try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+    List<Future<Response>> futures = urls.stream()
+        .map(url -> executor.submit(() -> httpClient.send(url)))
+        .toList();
+
+    List<Response> responses = futures.stream()
+        .map(f -> {
+            try { return f.get(); }
+            catch (Exception e) { throw new RuntimeException(e); }
+        })
+        .toList();
+}
+
+// Spring Boot 3.2+: enable virtual threads
+// spring.threads.virtual.enabled=true
+
+// Rules for virtual threads:
+// - Don't pool them (they're cheap to create)
+// - Don't use synchronized blocks for I/O (use ReentrantLock)
+// - Don't use ThreadLocal for request-scoped data (use ScopedValue)
+// - Perfect for: HTTP handlers, database queries, external API calls
+// - Not for: CPU-bound computation (use platform threads / ForkJoinPool)
+```
+
+## Anti-Patterns
+
+```java
+// Never: raw types
+List list = new ArrayList(); // What's in it?
+// Use: List<User> users = new ArrayList<>();
+
+// Never: checked exceptions for control flow
+try { return Integer.parseInt(input); }
+catch (NumberFormatException e) { return -1; }
+// Use validation before parsing
+
+// Never: mutable public fields
+public class Config {
+    public String url; // Anyone can change this
+}
+// Use: records, or private fields with getters
+
+// Never: null as a valid business value
+public User findUser(String id) {
+    return null; // Caller forgets null check → NPE
+}
+// Use: Optional<User> or throw NotFoundException
+```

--- a/templates/java-expert/.cursorrules/overview.md
+++ b/templates/java-expert/.cursorrules/overview.md
@@ -1,0 +1,81 @@
+# Java Expert Overview
+
+Principal-level Java engineering. Deep JVM knowledge, modern language features, and production-grade patterns.
+
+## Scope
+
+This guide applies to:
+- Web services and APIs (Spring Boot, Quarkus, Micronaut)
+- Microservices and distributed systems
+- Event-driven architectures (Kafka, RabbitMQ)
+- Batch processing and data pipelines
+- Libraries and Maven/Gradle artifacts
+- Cloud-native applications (Kubernetes, GraalVM native images)
+
+## Core Philosophy
+
+Java's strength is its ecosystem maturity and runtime reliability. The best Java code is clear, testable, and boring.
+
+- **Readability over cleverness.** A junior engineer should understand your code without a tutorial.
+- **Immutability by default.** Records, `final` fields, unmodifiable collections. Mutation is the exception.
+- **Composition over inheritance.** Interfaces, delegation, and dependency injection — not deep class hierarchies.
+- **The JVM is your ally.** Understand garbage collection, JIT compilation, and memory model — don't fight them.
+- **Fail fast, fail loud.** Validate at boundaries, throw meaningful exceptions, never swallow errors.
+- **If you don't know, say so.** Admitting uncertainty is professional. Guessing at JVM behavior you haven't verified is not.
+
+## Key Principles
+
+1. **Modern Java Is Required** — Java 21+ features: records, sealed classes, pattern matching, virtual threads
+2. **Null Is a Bug** — Use `Optional` for return types, `@Nullable`/`@NonNull` annotations, and validation at boundaries
+3. **Dependency Injection Is the Architecture** — Constructor injection, interface segregation, Spring's application context
+4. **Tests Are Documentation** — Descriptive names, Arrange-Act-Assert, behavior over implementation
+5. **Observability Is Not Optional** — Structured logging, metrics, distributed tracing from day one
+
+## Project Structure
+
+```
+project/
+├── src/main/java/com/example/myapp/
+│   ├── Application.java              # Entry point
+│   ├── config/                        # Configuration classes
+│   ├── domain/                        # Core domain (no framework deps)
+│   │   ├── model/                     # Entities, value objects, records
+│   │   ├── service/                   # Domain services
+│   │   └── event/                     # Domain events
+│   ├── application/                   # Use cases, orchestration
+│   │   ├── command/                   # Write operations
+│   │   ├── query/                     # Read operations
+│   │   └── port/                      # Interfaces (driven/driving)
+│   ├── infrastructure/                # External concerns
+│   │   ├── persistence/               # JPA repositories, entity mappings
+│   │   ├── messaging/                 # Kafka/RabbitMQ producers/consumers
+│   │   └── client/                    # HTTP clients, external APIs
+│   └── api/                           # REST controllers, DTOs
+│       ├── controller/
+│       ├── dto/
+│       └── exception/                 # Exception handlers
+├── src/main/resources/
+│   ├── application.yml
+│   └── db/migration/                  # Flyway/Liquibase migrations
+├── src/test/java/com/example/myapp/
+│   ├── unit/
+│   ├── integration/
+│   └── architecture/
+├── pom.xml or build.gradle.kts
+└── Dockerfile
+```
+
+## Definition of Done
+
+A Java feature is complete when:
+
+- [ ] Code compiles with zero warnings (`-Xlint:all -Werror`)
+- [ ] All tests pass (`mvn verify` or `gradle check`)
+- [ ] No SpotBugs/ErrorProne findings
+- [ ] No SonarQube code smells or security hotspots
+- [ ] Null safety enforced (no raw `null` returns from public APIs)
+- [ ] Javadoc on all public classes and methods
+- [ ] Error paths are tested
+- [ ] Thread safety verified for shared mutable state
+- [ ] No `TODO` without an associated issue
+- [ ] Code reviewed and approved

--- a/templates/java-expert/.cursorrules/performance.md
+++ b/templates/java-expert/.cursorrules/performance.md
@@ -1,0 +1,239 @@
+# Java Performance
+
+The JVM is a world-class runtime. Understand it, don't fight it. Measure first.
+
+## Profile Before Optimizing
+
+```bash
+# JFR (Java Flight Recorder) — production-safe profiling
+java -XX:StartFlightRecording=filename=recording.jfr,duration=60s -jar app.jar
+
+# Async-profiler — low-overhead sampling
+./asprof -d 30 -f profile.html <pid>
+
+# JVM flags for diagnostics
+-XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xlog:gc*:file=gc.log
+```
+
+### Diagnostic Tools
+
+| Tool | Purpose |
+|------|---------|
+| JFR + JMC | Production profiling (CPU, memory, I/O, locks) |
+| async-profiler | Low-overhead CPU/allocation profiling |
+| JMH | Micro-benchmarks with statistical rigor |
+| jcmd | Runtime diagnostics (heap dump, thread dump) |
+| VisualVM | Real-time monitoring |
+
+## JMH Benchmarks
+
+```java
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class StringConcatBenchmark {
+
+    private List<String> items;
+
+    @Setup
+    public void setup() {
+        items = IntStream.range(0, 1000)
+            .mapToObj(Integer::toString)
+            .toList();
+    }
+
+    @Benchmark
+    public String concatenation() {
+        var result = "";
+        for (var item : items) result += item;
+        return result;
+    }
+
+    @Benchmark
+    public String stringBuilder() {
+        var sb = new StringBuilder();
+        for (var item : items) sb.append(item);
+        return sb.toString();
+    }
+
+    @Benchmark
+    public String stringJoin() {
+        return String.join("", items);
+    }
+}
+```
+
+## GC Tuning
+
+```bash
+# G1GC (default, good for most workloads)
+-XX:+UseG1GC
+-XX:MaxGCPauseMillis=200
+
+# ZGC (ultra-low latency, Java 21+ production-ready)
+-XX:+UseZGC
+-XX:+ZGenerational  # Generational ZGC (Java 21+)
+
+# Heap sizing
+-Xms2g -Xmx2g      # Fixed heap size (no resize pauses)
+-XX:+AlwaysPreTouch # Touch memory pages at startup
+```
+
+### GC Rules
+
+- Start with G1GC defaults — they're good
+- Use ZGC if you need < 1ms pause times
+- Set `-Xms` = `-Xmx` for predictable behavior
+- Monitor with JFR, not gut feeling
+
+## Memory Patterns
+
+### Avoid Unnecessary Allocations
+
+```java
+// Bad: autoboxing in hot loops
+long sum = 0;
+for (Integer value : integerList) {
+    sum += value; // Unboxing on every iteration
+}
+
+// Good: use primitive streams
+long sum = integerList.stream().mapToLong(Integer::longValue).sum();
+
+// Bad: intermediate collections
+var result = users.stream()
+    .map(User::name)
+    .collect(Collectors.toList()) // Intermediate list
+    .stream()
+    .filter(n -> n.startsWith("A"))
+    .toList();
+
+// Good: single pipeline
+var result = users.stream()
+    .map(User::name)
+    .filter(n -> n.startsWith("A"))
+    .toList();
+```
+
+### String Optimization
+
+```java
+// String.intern() for repeated strings (use carefully — fills PermGen/Metaspace)
+// Better: use enum or constants for known string sets
+
+// StringBuilder for complex concatenation
+var sb = new StringBuilder(256); // Pre-size if length is known
+for (var item : items) {
+    sb.append(item.name()).append(": ").append(item.value()).append('\n');
+}
+return sb.toString();
+```
+
+### Collection Sizing
+
+```java
+// Pre-size collections when capacity is known
+var map = new HashMap<String, User>(expectedSize * 4 / 3 + 1); // Account for load factor
+var list = new ArrayList<User>(expectedSize);
+
+// Use specialized collections
+EnumMap<Status, List<Order>> byStatus = new EnumMap<>(Status.class);
+EnumSet<Permission> permissions = EnumSet.of(READ, WRITE);
+```
+
+## Connection Pooling (HikariCP)
+
+```yaml
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 10         # Default is fine for most apps
+      minimum-idle: 5
+      idle-timeout: 300000          # 5 minutes
+      connection-timeout: 30000     # 30 seconds
+      max-lifetime: 1800000         # 30 minutes
+      leak-detection-threshold: 60000  # 1 minute — detect leaked connections
+```
+
+### Pool Sizing Rule
+
+Formula: `connections = (core_count * 2) + effective_spindle_count`
+For SSDs: `connections ≈ core_count * 2`
+
+Most apps need 10-20 connections. More is rarely better.
+
+## HTTP Client Performance
+
+```java
+// Shared HttpClient instance with connection pooling
+private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+    .connectTimeout(Duration.ofSeconds(5))
+    .executor(Executors.newVirtualThreadPerTaskExecutor())
+    .build();
+
+// Or with Spring: RestClient / WebClient (reuse instances)
+@Bean
+public RestClient restClient(RestClient.Builder builder) {
+    return builder
+        .baseUrl("https://api.example.com")
+        .requestFactory(new JdkClientHttpRequestFactory(HTTP_CLIENT))
+        .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+        .build();
+}
+```
+
+## Caching
+
+```java
+// Spring Cache with Caffeine (in-process)
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        var caffeine = Caffeine.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(Duration.ofMinutes(10))
+            .recordStats();
+
+        var manager = new CaffeineCacheManager();
+        manager.setCaffeine(caffeine);
+        return manager;
+    }
+}
+
+@Cacheable(value = "users", key = "#id")
+public Optional<User> findById(UUID id) {
+    return userRepository.findById(id);
+}
+
+@CacheEvict(value = "users", key = "#user.id")
+public void update(User user) {
+    userRepository.save(user);
+}
+```
+
+## Anti-Patterns
+
+```java
+// Never: premature optimization without profiling
+// "I think this is slow" — prove it with JMH or JFR
+
+// Never: creating threads manually
+new Thread(() -> process(item)).start(); // No lifecycle management, no error handling
+// Use ExecutorService or virtual threads
+
+// Never: synchronizing on string literals
+synchronized ("lock") { } // String interning means unexpected sharing
+// Use: private final Object lock = new Object();
+
+// Never: reflection in hot paths
+method.invoke(target, args); // Orders of magnitude slower than direct calls
+// Use interfaces and polymorphism
+
+// Never: unbounded caches
+private final Map<String, Object> cache = new HashMap<>(); // Grows forever → OOM
+// Use Caffeine with eviction policies
+```

--- a/templates/java-expert/.cursorrules/persistence.md
+++ b/templates/java-expert/.cursorrules/persistence.md
@@ -1,0 +1,262 @@
+# Java Persistence
+
+JPA/Hibernate done right, JDBC when you need control, and database patterns that scale.
+
+## JPA Entity Design
+
+```java
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String customerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> items = new ArrayList<>();
+
+    @Version
+    private Long version; // Optimistic locking
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+
+    // Protected no-arg constructor for JPA
+    protected Order() {}
+
+    // Factory method with validation
+    public static Order create(String customerId, List<OrderItem> items) {
+        Objects.requireNonNull(customerId, "customerId is required");
+        if (items.isEmpty()) throw new IllegalArgumentException("Order must have items");
+
+        var order = new Order();
+        order.customerId = customerId;
+        order.status = OrderStatus.PENDING;
+        items.forEach(order::addItem);
+        return order;
+    }
+
+    public void addItem(OrderItem item) {
+        items.add(item);
+        item.setOrder(this);
+    }
+
+    // Getters only — no public setters for domain-relevant fields
+    public UUID getId() { return id; }
+    public OrderStatus getStatus() { return status; }
+    public List<OrderItem> getItems() { return Collections.unmodifiableList(items); }
+}
+```
+
+## Repository Pattern
+
+```java
+// Spring Data JPA — let the framework generate implementations
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+
+    // Derived query
+    List<Order> findByCustomerIdAndStatus(String customerId, OrderStatus status);
+
+    // JPQL for complex queries
+    @Query("""
+        SELECT o FROM Order o
+        JOIN FETCH o.items
+        WHERE o.customerId = :customerId
+        ORDER BY o.createdAt DESC
+        """)
+    List<Order> findWithItemsByCustomerId(@Param("customerId") String customerId);
+
+    // Native query when JPQL isn't enough
+    @Query(value = """
+        SELECT o.* FROM orders o
+        WHERE o.created_at > :since
+          AND o.status = 'PENDING'
+        FOR UPDATE SKIP LOCKED
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<Order> findPendingForProcessing(
+        @Param("since") Instant since,
+        @Param("limit") int limit);
+
+    // Projections for read-only queries
+    @Query("""
+        SELECT new com.example.dto.OrderSummary(o.id, o.status, o.createdAt, SIZE(o.items))
+        FROM Order o
+        WHERE o.customerId = :customerId
+        """)
+    Page<OrderSummary> findSummariesByCustomerId(
+        @Param("customerId") String customerId, Pageable pageable);
+}
+```
+
+## Transaction Management
+
+```java
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final PaymentService paymentService;
+    private final TransactionTemplate txTemplate;
+
+    // Declarative — for simple cases
+    @Transactional
+    public Order create(CreateOrderRequest request) {
+        var order = Order.create(request.customerId(), request.items());
+        return orderRepository.save(order);
+    }
+
+    // Read-only transactions — enables optimizations
+    @Transactional(readOnly = true)
+    public Optional<Order> findById(UUID id) {
+        return orderRepository.findById(id);
+    }
+
+    // Programmatic — for fine-grained control
+    public OrderResult processOrder(UUID orderId) {
+        // Step 1: Update order status (transactional)
+        var order = txTemplate.execute(status -> {
+            var o = orderRepository.findById(orderId)
+                .orElseThrow(() -> new NotFoundException("Order: " + orderId));
+            o.markProcessing();
+            return orderRepository.save(o);
+        });
+
+        // Step 2: Call external payment (non-transactional)
+        var paymentResult = paymentService.charge(order);
+
+        // Step 3: Update with result (new transaction)
+        return txTemplate.execute(status -> {
+            if (paymentResult.isSuccess()) {
+                order.markPaid(paymentResult.transactionId());
+            } else {
+                order.markFailed(paymentResult.errorMessage());
+            }
+            orderRepository.save(order);
+            return OrderResult.from(order);
+        });
+    }
+}
+```
+
+## N+1 Query Prevention
+
+```java
+// Bad: lazy loading in a loop
+var orders = orderRepository.findAll(); // 1 query
+for (var order : orders) {
+    order.getItems().size(); // N queries!
+}
+
+// Good: JOIN FETCH
+@Query("SELECT o FROM Order o JOIN FETCH o.items WHERE o.status = :status")
+List<Order> findWithItemsByStatus(@Param("status") OrderStatus status);
+
+// Good: @EntityGraph
+@EntityGraph(attributePaths = {"items", "customer"})
+List<Order> findByStatus(OrderStatus status);
+
+// Good: DTO projection (best performance)
+@Query("""
+    SELECT new com.example.dto.OrderSummary(o.id, o.status, SIZE(o.items))
+    FROM Order o WHERE o.status = :status
+    """)
+List<OrderSummary> findSummariesByStatus(@Param("status") OrderStatus status);
+```
+
+## Database Migrations (Flyway)
+
+```sql
+-- V1__create_orders_table.sql
+CREATE TABLE orders (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id VARCHAR(255) NOT NULL,
+    status      VARCHAR(50) NOT NULL DEFAULT 'PENDING',
+    version     BIGINT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_orders_customer_id ON orders(customer_id);
+CREATE INDEX idx_orders_status ON orders(status);
+
+-- V2__add_order_items_table.sql
+CREATE TABLE order_items (
+    id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_id UUID NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    sku      VARCHAR(100) NOT NULL,
+    quantity INT NOT NULL CHECK (quantity > 0),
+    price    NUMERIC(10, 2) NOT NULL CHECK (price >= 0)
+);
+
+CREATE INDEX idx_order_items_order_id ON order_items(order_id);
+```
+
+## JDBC Template (When JPA Is Overkill)
+
+```java
+// For bulk operations, complex queries, or maximum performance
+@Repository
+@RequiredArgsConstructor
+public class OrderReportRepository {
+
+    private final JdbcTemplate jdbc;
+
+    public List<DailyRevenue> getDailyRevenue(LocalDate from, LocalDate to) {
+        return jdbc.query("""
+            SELECT DATE(created_at) as day, SUM(total) as revenue, COUNT(*) as order_count
+            FROM orders
+            WHERE created_at BETWEEN ? AND ?
+              AND status = 'COMPLETED'
+            GROUP BY DATE(created_at)
+            ORDER BY day
+            """,
+            (rs, rowNum) -> new DailyRevenue(
+                rs.getDate("day").toLocalDate(),
+                rs.getBigDecimal("revenue"),
+                rs.getInt("order_count")),
+            from, to);
+    }
+}
+```
+
+## Anti-Patterns
+
+```java
+// Never: open-in-view (lazy loading in presentation layer)
+spring.jpa.open-in-view=true // Masks N+1 problems, unclear data boundaries
+
+// Never: entities as API responses
+@GetMapping("/{id}")
+public Order getById(@PathVariable UUID id) {
+    return orderRepository.findById(id).orElseThrow();
+    // Exposes internal structure, lazy loading exceptions, circular references
+}
+// Map to DTOs/records
+
+// Never: manual ID generation with UUID.randomUUID() in application code
+// Let the database or JPA strategy handle it
+
+// Never: ignoring @Version for concurrent writes
+// Optimistic locking prevents lost updates — use it
+
+// Never: long-running transactions
+@Transactional
+public void processAllOrders() {
+    var orders = orderRepository.findAll(); // Locks for entire method
+    orders.forEach(this::processExpensiveOperation);
+}
+// Process in batches with separate transactions
+```

--- a/templates/java-expert/.cursorrules/spring-boot.md
+++ b/templates/java-expert/.cursorrules/spring-boot.md
@@ -1,0 +1,262 @@
+# Spring Boot Patterns
+
+Production-grade Spring Boot development. Convention over configuration, done right.
+
+## Application Structure
+
+```java
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}
+// That's it. No XML. No component scanning tricks. Just this.
+```
+
+## REST Controllers
+
+```java
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<OrderResponse> getById(@PathVariable UUID id) {
+        return orderService.findById(id)
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<OrderResponse> create(
+            @Valid @RequestBody CreateOrderRequest request) {
+        var order = orderService.create(request);
+        var location = URI.create("/api/v1/orders/" + order.id());
+        return ResponseEntity.created(location).body(order);
+    }
+
+    @GetMapping
+    public Page<OrderResponse> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return orderService.findAll(PageRequest.of(page, size));
+    }
+}
+```
+
+## Service Layer
+
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final InventoryClient inventoryClient;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public Optional<OrderResponse> findById(UUID id) {
+        return orderRepository.findById(id)
+            .map(OrderResponse::from);
+    }
+
+    @Transactional
+    public OrderResponse create(CreateOrderRequest request) {
+        // Validate business rules
+        inventoryClient.checkAvailability(request.items())
+            .orElseThrow(() -> new InsufficientInventoryException(request.items()));
+
+        // Create and persist
+        var order = Order.create(request);
+        orderRepository.save(order);
+
+        // Publish domain event
+        eventPublisher.publishEvent(new OrderCreatedEvent(order.getId()));
+
+        return OrderResponse.from(order);
+    }
+}
+```
+
+## Configuration
+
+```java
+// Strongly typed configuration with validation
+@Validated
+@ConfigurationProperties(prefix = "app.orders")
+public record OrderProperties(
+    @NotNull Duration processingTimeout,
+    @Min(1) @Max(1000) int maxItemsPerOrder,
+    @NotBlank String notificationEmail
+) {}
+
+// Enable in Application class or config
+@EnableConfigurationProperties(OrderProperties.class)
+
+// application.yml
+// app:
+//   orders:
+//     processing-timeout: 30s
+//     max-items-per-order: 50
+//     notification-email: orders@example.com
+```
+
+## Exception Handling
+
+```java
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ProblemDetail handleNotFound(NotFoundException ex) {
+        var problem = ProblemDetail.forStatusAndDetail(
+            HttpStatus.NOT_FOUND, ex.getMessage());
+        problem.setTitle("Resource Not Found");
+        return problem;
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ProblemDetail handleValidation(MethodArgumentNotValidException ex) {
+        var problem = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        problem.setTitle("Validation Failed");
+        var errors = ex.getBindingResult().getFieldErrors().stream()
+            .collect(Collectors.toMap(
+                FieldError::getField,
+                f -> Objects.requireNonNullElse(f.getDefaultMessage(), "Invalid")));
+        problem.setProperty("errors", errors);
+        return problem;
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleUnexpected(Exception ex) {
+        log.error("Unexpected error", ex);
+        return ProblemDetail.forStatusAndDetail(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "An unexpected error occurred");
+        // Never expose stack traces or internal details to clients
+    }
+}
+```
+
+## Security
+
+```java
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(csrf -> csrf.csrfTokenRepository(
+                CookieCsrfTokenRepository.withHttpOnlyFalse()))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/public/**").permitAll()
+                .requestMatchers("/actuator/health").permitAll()
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                .anyRequest().authenticated())
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .build();
+    }
+}
+```
+
+## Health Checks
+
+```java
+@Component
+public class ExternalServiceHealthIndicator implements HealthIndicator {
+
+    private final ExternalServiceClient client;
+
+    @Override
+    public Health health() {
+        try {
+            client.ping();
+            return Health.up()
+                .withDetail("service", "external-api")
+                .build();
+        } catch (Exception ex) {
+            return Health.down()
+                .withDetail("service", "external-api")
+                .withException(ex)
+                .build();
+        }
+    }
+}
+
+// application.yml
+// management:
+//   endpoints:
+//     web:
+//       exposure:
+//         include: health,info,prometheus
+//   endpoint:
+//     health:
+//       show-details: when-authorized
+```
+
+## Profiles and Environment
+
+```yaml
+# application.yml — shared defaults
+spring:
+  application:
+    name: order-service
+  jpa:
+    open-in-view: false  # Always disable — prevents lazy loading bugs
+
+---
+# application-local.yml
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:postgresql://localhost:5432/orders
+
+---
+# application-prod.yml
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: ${DATABASE_URL}  # From environment
+```
+
+## Anti-Patterns
+
+```java
+// Never: field injection
+@Autowired
+private OrderRepository repository; // Untestable, hides dependencies
+// Use constructor injection (Lombok @RequiredArgsConstructor)
+
+// Never: business logic in controllers
+@PostMapping
+public Order create(@RequestBody CreateOrderRequest request) {
+    var order = new Order();
+    order.setStatus("PENDING");
+    order.setItems(request.items()); // Logic belongs in service/domain
+    return orderRepository.save(order);
+}
+
+// Never: open-in-view (lazy loading in controllers)
+spring.jpa.open-in-view=true // N+1 queries, unclear data access patterns
+// Set to false, use eager fetching or DTOs
+
+// Never: catching and ignoring exceptions
+try { externalService.call(); }
+catch (Exception e) { /* ignore */ }
+// Log, wrap, or rethrow — never swallow
+
+// Never: @Transactional on private methods (Spring proxy can't intercept them)
+```

--- a/templates/java-expert/.cursorrules/testing.md
+++ b/templates/java-expert/.cursorrules/testing.md
@@ -1,0 +1,272 @@
+# Java Testing
+
+Test behavior, not implementation. Every test answers: "what does this code do?"
+
+## Framework Stack
+
+| Tool | Purpose |
+|------|---------|
+| JUnit 5 | Test framework |
+| AssertJ | Fluent assertions |
+| Mockito | Mocking (with strict stubs) |
+| Testcontainers | Real databases/services |
+| Spring Boot Test | Integration testing |
+| WireMock | HTTP API mocking |
+| ArchUnit | Architecture tests |
+
+## Unit Test Structure
+
+```java
+class OrderServiceTest {
+
+    private final OrderRepository repository = mock(OrderRepository.class);
+    private final InventoryClient inventory = mock(InventoryClient.class);
+    private final OrderService sut = new OrderService(repository, inventory);
+
+    @Test
+    void create_withValidRequest_savesAndReturnsOrder() {
+        // Arrange
+        var request = new CreateOrderRequest("customer-1", List.of(
+            new OrderItemRequest("SKU-001", 2)));
+        when(inventory.checkAvailability("SKU-001", 2)).thenReturn(true);
+
+        // Act
+        var result = sut.create(request);
+
+        // Assert
+        assertThat(result.customerId()).isEqualTo("customer-1");
+        assertThat(result.status()).isEqualTo(OrderStatus.PENDING);
+        verify(repository).save(any(Order.class));
+    }
+
+    @Test
+    void create_withInsufficientInventory_throwsException() {
+        var request = new CreateOrderRequest("customer-1", List.of(
+            new OrderItemRequest("SKU-001", 100)));
+        when(inventory.checkAvailability("SKU-001", 100)).thenReturn(false);
+
+        assertThatThrownBy(() -> sut.create(request))
+            .isInstanceOf(InsufficientInventoryException.class)
+            .hasMessageContaining("SKU-001");
+
+        verify(repository, never()).save(any());
+    }
+}
+```
+
+## Test Naming
+
+```java
+// Pattern: method_scenario_expectedBehavior
+@Test void findById_whenExists_returnsUser() {}
+@Test void findById_whenNotFound_returnsEmpty() {}
+@Test void create_withDuplicateEmail_throwsConflictException() {}
+
+// Or descriptive sentences
+@Test void newly_created_order_has_pending_status() {}
+@Test void expired_orders_are_automatically_cancelled() {}
+```
+
+## Parameterized Tests
+
+```java
+@ParameterizedTest
+@CsvSource({
+    "'',       false",
+    "ab,       false",
+    "abc,      true",
+    "valid123, true"
+})
+void validatePassword_checksMinLength(String input, boolean expected) {
+    assertThat(PasswordValidator.isValid(input)).isEqualTo(expected);
+}
+
+@ParameterizedTest
+@MethodSource("invalidOrderRequests")
+void create_withInvalidData_throwsValidationException(CreateOrderRequest request) {
+    assertThatThrownBy(() -> sut.create(request))
+        .isInstanceOf(ValidationException.class);
+}
+
+static Stream<Arguments> invalidOrderRequests() {
+    return Stream.of(
+        Arguments.of(new CreateOrderRequest(null, List.of())),
+        Arguments.of(new CreateOrderRequest("", List.of())),
+        Arguments.of(new CreateOrderRequest("c1", List.of()))
+    );
+}
+```
+
+## Spring Boot Integration Tests
+
+```java
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class OrderControllerIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @BeforeEach
+    void setUp() {
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    void postOrders_withValidRequest_returnsCreated() {
+        var request = new CreateOrderRequest("customer-1", List.of(
+            new OrderItemRequest("SKU-001", 2)));
+
+        var response = restTemplate.postForEntity("/api/v1/orders", request, OrderResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().customerId()).isEqualTo("customer-1");
+        assertThat(response.getHeaders().getLocation()).isNotNull();
+    }
+
+    @Test
+    void getOrders_whenNotFound_returns404() {
+        var response = restTemplate.getForEntity(
+            "/api/v1/orders/" + UUID.randomUUID(), ProblemDetail.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+}
+```
+
+## WireMock for External APIs
+
+```java
+@SpringBootTest
+@WireMockTest(httpPort = 8089)
+class PaymentServiceTest {
+
+    @Autowired
+    private PaymentService paymentService;
+
+    @Test
+    void charge_whenPaymentSucceeds_returnsTransactionId() {
+        stubFor(post("/payments/charge")
+            .willReturn(okJson("""
+                {"transactionId": "tx-123", "status": "SUCCESS"}
+                """)));
+
+        var result = paymentService.charge(new ChargeRequest("order-1", BigDecimal.TEN));
+
+        assertThat(result.transactionId()).isEqualTo("tx-123");
+        verify(postRequestedFor(urlEqualTo("/payments/charge"))
+            .withRequestBody(matchingJsonPath("$.orderId", equalTo("order-1"))));
+    }
+
+    @Test
+    void charge_whenPaymentServiceDown_throwsException() {
+        stubFor(post("/payments/charge")
+            .willReturn(serverError()));
+
+        assertThatThrownBy(() -> paymentService.charge(
+            new ChargeRequest("order-1", BigDecimal.TEN)))
+            .isInstanceOf(PaymentException.class);
+    }
+}
+```
+
+## Architecture Tests (ArchUnit)
+
+```java
+class ArchitectureTest {
+
+    private final JavaClasses classes = new ClassFileImporter()
+        .importPackages("com.example.myapp");
+
+    @Test
+    void domain_should_not_depend_on_infrastructure() {
+        noClasses()
+            .that().resideInAPackage("..domain..")
+            .should().dependOnClassesThat()
+            .resideInAnyPackage("..infrastructure..", "..api..")
+            .check(classes);
+    }
+
+    @Test
+    void controllers_should_not_access_repositories_directly() {
+        noClasses()
+            .that().resideInAPackage("..api..")
+            .should().dependOnClassesThat()
+            .resideInAPackage("..persistence..")
+            .check(classes);
+    }
+
+    @Test
+    void services_should_be_annotated_with_service() {
+        classes()
+            .that().resideInAPackage("..application..")
+            .and().haveSimpleNameEndingWith("Service")
+            .should().beAnnotatedWith(Service.class)
+            .check(classes);
+    }
+}
+```
+
+## Test Data Builders
+
+```java
+public class TestOrders {
+
+    public static Order.Builder aValidOrder() {
+        return Order.builder()
+            .customerId("customer-1")
+            .status(OrderStatus.PENDING)
+            .items(List.of(anOrderItem().build()));
+    }
+
+    public static OrderItem.Builder anOrderItem() {
+        return OrderItem.builder()
+            .sku("SKU-" + ThreadLocalRandom.current().nextInt(1000))
+            .quantity(1)
+            .price(BigDecimal.valueOf(9.99));
+    }
+}
+
+// Usage in tests
+var order = TestOrders.aValidOrder()
+    .status(OrderStatus.SHIPPED)
+    .build();
+```
+
+## Anti-Patterns
+
+```java
+// Never: testing implementation details
+verify(repository, times(1)).save(any()); // How, not what
+// Test the outcome: verify the order exists, has correct status
+
+// Never: @SpringBootTest for unit tests (slow startup)
+@SpringBootTest // Loads entire context for testing one service
+class OrderServiceTest {} // Use plain JUnit + Mockito instead
+
+// Never: Thread.sleep in tests
+Thread.sleep(5000); // Flaky and slow
+// Use Awaitility: await().atMost(5, SECONDS).until(() -> condition);
+
+// Never: shared mutable state between tests
+static List<Order> testOrders = new ArrayList<>(); // Tests pollute each other
+// Use @BeforeEach to reset state
+
+// Never: ignoring test failures with @Disabled without a reason
+@Disabled // Why? When will it be fixed?
+@Disabled("Flaky due to #1234 — external API timeout. Fix by 2025-02-01")
+```

--- a/templates/java-expert/.cursorrules/tooling.md
+++ b/templates/java-expert/.cursorrules/tooling.md
@@ -1,0 +1,301 @@
+# Java Tooling and Build Systems
+
+Maven or Gradle. Static analysis. CI/CD. Docker. The full production pipeline.
+
+## Build Tools
+
+### Maven
+
+```xml
+<!-- pom.xml essentials -->
+<properties>
+    <java.version>21</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+</properties>
+
+<!-- Dependency management in parent POM -->
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-dependencies</artifactId>
+            <version>${spring-boot.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<!-- Essential plugins -->
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <compilerArgs>
+                    <arg>-Xlint:all</arg>
+                    <arg>-Werror</arg>
+                </compilerArgs>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+                <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+### Gradle (Kotlin DSL)
+
+```kotlin
+// build.gradle.kts
+plugins {
+    java
+    id("org.springframework.boot") version "3.4.0"
+    id("io.spring.dependency-management") version "1.1.6"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.addAll(listOf("-Xlint:all", "-Werror"))
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("org.flywaydb:flyway-database-postgresql")
+
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:junit-jupiter")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
+}
+```
+
+## Essential Commands
+
+```bash
+# Maven
+mvn clean verify                     # Full build + tests
+mvn test                             # Unit tests only
+mvn verify -Pintegration-tests       # Integration tests
+mvn dependency:tree                  # Dependency analysis
+mvn versions:display-dependency-updates  # Check for updates
+mvn spotbugs:check                   # Static analysis
+
+# Gradle
+./gradlew clean build                # Full build + tests
+./gradlew test                       # Unit tests
+./gradlew integrationTest            # Integration tests
+./gradlew dependencies               # Dependency tree
+./gradlew dependencyUpdates          # Check for updates
+```
+
+## Static Analysis
+
+### SpotBugs + ErrorProne
+
+```xml
+<!-- SpotBugs -->
+<plugin>
+    <groupId>com.github.spotbugs</groupId>
+    <artifactId>spotbugs-maven-plugin</artifactId>
+    <configuration>
+        <effort>Max</effort>
+        <threshold>Low</threshold>
+        <failOnError>true</failOnError>
+    </configuration>
+</plugin>
+
+<!-- ErrorProne (compile-time bug detection) -->
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <configuration>
+        <annotationProcessorPaths>
+            <path>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>${errorprone.version}</version>
+            </path>
+        </annotationProcessorPaths>
+        <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+        </compilerArgs>
+    </configuration>
+</plugin>
+```
+
+### Checkstyle
+
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-checkstyle-plugin</artifactId>
+    <configuration>
+        <configLocation>google_checks.xml</configLocation>
+        <failsOnError>true</failsOnError>
+    </configuration>
+</plugin>
+```
+
+## Docker
+
+```dockerfile
+# Multi-stage build
+FROM eclipse-temurin:21-jdk-alpine AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn package -DskipTests -q
+
+FROM eclipse-temurin:21-jre-alpine
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+
+# JVM tuning for containers
+ENV JAVA_OPTS="-XX:+UseContainerSupport \
+    -XX:MaxRAMPercentage=75.0 \
+    -XX:+UseZGC \
+    -XX:+ZGenerational"
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]
+```
+
+## CI/CD (GitHub Actions)
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Build and test
+        run: mvn clean verify -B
+        env:
+          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/testdb
+          SPRING_DATASOURCE_USERNAME: postgres
+          SPRING_DATASOURCE_PASSWORD: test
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+```
+
+## Logging (SLF4J + Logback)
+
+```java
+// Always use SLF4J facade
+private static final Logger log = LoggerFactory.getLogger(OrderService.class);
+// Or with Lombok: @Slf4j on the class
+
+// Structured logging with parameters — never string concatenation
+log.info("Order created orderId={} customerId={} itemCount={}",
+    order.getId(), order.getCustomerId(), order.getItems().size());
+
+// MDC for request-scoped context
+MDC.put("requestId", requestId);
+MDC.put("userId", userId);
+try {
+    // All log statements in this scope include requestId and userId
+    processOrder(order);
+} finally {
+    MDC.clear();
+}
+```
+
+```xml
+<!-- logback-spring.xml for JSON output in production -->
+<configuration>
+    <springProfile name="prod">
+        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        </appender>
+    </springProfile>
+
+    <springProfile name="local">
+        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+    </springProfile>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>
+```
+
+## Anti-Patterns
+
+```java
+// Never: System.out.println for logging
+System.out.println("Order created: " + order.getId());
+// Use SLF4J logger
+
+// Never: hardcoded versions scattered across modules
+// Use dependencyManagement (Maven) or platform (Gradle)
+
+// Never: fat JAR without layer optimization
+// Use Spring Boot layered JARs for Docker cache efficiency
+
+// Never: running as root in Docker containers
+USER root // Security risk
+// Use: non-root user (adduser)
+
+// Never: skipping static analysis in CI
+// SpotBugs, ErrorProne, and Checkstyle catch real bugs
+```

--- a/templates/java-expert/CLAUDE.md
+++ b/templates/java-expert/CLAUDE.md
@@ -1,0 +1,325 @@
+# Java Expert Development Guide
+
+Principal-level guidelines for Java engineering. Deep JVM knowledge, modern language features, and production-grade patterns.
+
+---
+
+## Overview
+
+This guide applies to:
+- Web services and APIs (Spring Boot, Quarkus, Micronaut)
+- Microservices and distributed systems
+- Event-driven architectures (Kafka, RabbitMQ)
+- Batch processing and data pipelines
+- Libraries and Maven/Gradle artifacts
+- Cloud-native applications (Kubernetes, GraalVM native images)
+
+### Core Philosophy
+
+Java's strength is its ecosystem maturity and runtime reliability. The best Java code is clear, testable, and boring.
+
+- **Readability over cleverness.** A junior engineer should understand your code without a tutorial.
+- **Immutability by default.** Records, `final` fields, unmodifiable collections. Mutation is the exception.
+- **Composition over inheritance.** Interfaces, delegation, and dependency injection — not deep class hierarchies.
+- **The JVM is your ally.** Understand garbage collection, JIT compilation, and memory model — don't fight them.
+- **Fail fast, fail loud.** Validate at boundaries, throw meaningful exceptions, never swallow errors.
+- **If you don't know, say so.** Admitting uncertainty is professional. Guessing at JVM behavior you haven't verified is not.
+
+### Key Principles
+
+1. **Modern Java Is Required** — Java 21+ features: records, sealed classes, pattern matching, virtual threads
+2. **Null Is a Bug** — Use `Optional` for return types, `@Nullable`/`@NonNull` annotations, and validation at boundaries
+3. **Dependency Injection Is the Architecture** — Constructor injection, interface segregation, Spring's application context
+4. **Tests Are Documentation** — Descriptive names, Arrange-Act-Assert, behavior over implementation
+5. **Observability Is Not Optional** — Structured logging, metrics, distributed tracing from day one
+
+### Project Structure
+
+```
+project/
+├── src/main/java/com/example/myapp/
+│   ├── Application.java
+│   ├── config/
+│   ├── domain/
+│   │   ├── model/
+│   │   ├── service/
+│   │   └── event/
+│   ├── application/
+│   │   ├── command/
+│   │   ├── query/
+│   │   └── port/
+│   ├── infrastructure/
+│   │   ├── persistence/
+│   │   ├── messaging/
+│   │   └── client/
+│   └── api/
+│       ├── controller/
+│       ├── dto/
+│       └── exception/
+├── src/main/resources/
+│   ├── application.yml
+│   └── db/migration/
+├── src/test/java/
+├── pom.xml or build.gradle.kts
+└── Dockerfile
+```
+
+---
+
+## Modern Java
+
+### Records
+
+```java
+public record CreateUserRequest(@NotBlank String name, @Email String email) {}
+public record Money(BigDecimal amount, Currency currency) {
+    public Money {
+        if (amount.compareTo(BigDecimal.ZERO) < 0)
+            throw new IllegalArgumentException("Amount cannot be negative");
+    }
+}
+```
+
+### Sealed Classes
+
+```java
+public sealed interface PaymentResult
+    permits PaymentSuccess, PaymentFailure, PaymentPending {}
+
+public String describe(PaymentResult result) {
+    return switch (result) {
+        case PaymentSuccess s -> "Paid: " + s.transactionId();
+        case PaymentFailure f -> "Failed: " + f.message();
+        case PaymentPending p -> "Pending: " + p.referenceId();
+    };
+}
+```
+
+### Virtual Threads (Java 21+)
+
+```java
+try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+    var futures = tasks.stream()
+        .map(task -> executor.submit(() -> process(task)))
+        .toList();
+}
+// Don't pool them. Don't use synchronized for I/O. Use ReentrantLock instead.
+```
+
+---
+
+## Spring Boot
+
+### Service Layer
+
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+    private final OrderRepository orderRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public OrderResponse create(CreateOrderRequest request) {
+        var order = Order.create(request);
+        orderRepository.save(order);
+        eventPublisher.publishEvent(new OrderCreatedEvent(order.getId()));
+        return OrderResponse.from(order);
+    }
+}
+```
+
+### Exception Handling
+
+```java
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(NotFoundException.class)
+    public ProblemDetail handleNotFound(NotFoundException ex) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+}
+```
+
+### Configuration
+
+```java
+@Validated
+@ConfigurationProperties(prefix = "app.orders")
+public record OrderProperties(
+    @NotNull Duration processingTimeout,
+    @Min(1) int maxItemsPerOrder
+) {}
+```
+
+---
+
+## Concurrency
+
+### Rules
+
+- Don't start threads you can't stop
+- Prefer virtual threads for I/O, platform threads for CPU
+- Use `ReentrantLock` over `synchronized` with virtual threads
+- Always restore interrupt status in catch blocks
+- Immutable objects are inherently thread-safe
+
+### CompletableFuture
+
+```java
+var userFuture = CompletableFuture.supplyAsync(() -> userService.findById(userId));
+var ordersFuture = CompletableFuture.supplyAsync(() -> orderService.recent(userId));
+CompletableFuture.allOf(userFuture, ordersFuture)
+    .thenApply(v -> new Dashboard(userFuture.join(), ordersFuture.join()));
+```
+
+---
+
+## Persistence
+
+### JPA Best Practices
+
+- Factory methods on entities, protected no-arg constructors for JPA
+- `@Version` for optimistic locking
+- JOIN FETCH or `@EntityGraph` to prevent N+1 queries
+- DTO projections for read-only queries
+- `spring.jpa.open-in-view=false` — always
+
+### Transactions
+
+```java
+@Transactional(readOnly = true) // On the class for reads
+public Optional<Order> findById(UUID id) { ... }
+
+@Transactional // Override for writes
+public Order create(CreateOrderRequest request) { ... }
+```
+
+### Migrations
+
+Flyway or Liquibase. Every schema change is a versioned migration. No Hibernate auto-DDL in production.
+
+---
+
+## Error Handling
+
+### Two Approaches
+
+1. **Exceptions** — Infrastructure failures, programming errors
+2. **Result types** — Expected business failures (validation, conflicts)
+
+### Guard Clauses
+
+```java
+Objects.requireNonNull(customerId, "customerId must not be null");
+if (items.isEmpty()) throw new IllegalArgumentException("Order must have items");
+```
+
+### Logging
+
+```java
+log.error("Payment failed orderId={} amount={}: {}", orderId, amount, ex.getMessage(), ex);
+// Parameters for structured logging. Exception as last arg for stack trace.
+```
+
+---
+
+## Testing
+
+### Framework Stack
+
+| Tool | Purpose |
+|------|---------|
+| JUnit 5 | Test framework |
+| AssertJ | Fluent assertions |
+| Mockito | Mocking |
+| Testcontainers | Real databases/services |
+| WireMock | HTTP API mocking |
+| ArchUnit | Architecture tests |
+
+### Test Structure
+
+```java
+@Test
+void create_withValidRequest_savesAndReturnsOrder() {
+    // Arrange
+    var request = new CreateOrderRequest("customer-1", List.of(item));
+    when(inventory.check("SKU-001", 2)).thenReturn(true);
+    // Act
+    var result = sut.create(request);
+    // Assert
+    assertThat(result.customerId()).isEqualTo("customer-1");
+}
+```
+
+### Integration Tests
+
+```java
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@Testcontainers
+class OrderControllerIT {
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+}
+```
+
+---
+
+## Performance
+
+### Profile First
+
+```bash
+java -XX:StartFlightRecording=filename=recording.jfr,duration=60s -jar app.jar
+```
+
+### Key Patterns
+
+- Pre-size collections when capacity is known
+- Use primitive streams to avoid autoboxing
+- `StringBuilder` for complex string concatenation
+- HikariCP pool sizing: `core_count * 2` connections
+- Caffeine for in-process caching with eviction
+- ZGC for ultra-low-latency requirements
+
+---
+
+## Tooling
+
+### Essential Stack
+
+| Tool | Purpose |
+|------|---------|
+| Maven/Gradle | Build system |
+| SpotBugs | Bug detection |
+| ErrorProne | Compile-time bug detection |
+| Checkstyle | Code style enforcement |
+| JFR + JMC | Production profiling |
+| JMH | Micro-benchmarks |
+| SLF4J + Logback | Logging |
+
+### CI Essentials
+
+```bash
+mvn clean verify -B         # Full build with tests
+mvn spotbugs:check           # Static analysis
+mvn checkstyle:check         # Code style
+```
+
+---
+
+## Definition of Done
+
+A Java feature is complete when:
+
+- [ ] Code compiles with zero warnings (`-Xlint:all -Werror`)
+- [ ] All tests pass (`mvn verify` or `gradle check`)
+- [ ] No SpotBugs/ErrorProne findings
+- [ ] No SonarQube code smells or security hotspots
+- [ ] Null safety enforced (no raw `null` returns from public APIs)
+- [ ] Javadoc on all public classes and methods
+- [ ] Error paths are tested
+- [ ] Thread safety verified for shared mutable state
+- [ ] No `TODO` without an associated issue
+- [ ] Code reviewed and approved


### PR DESCRIPTION
## Summary

- Adds principal-level Java expert template with 9 rule files covering modern Java 21+, Spring Boot, concurrency, JPA persistence, error handling, testing, performance, and tooling
- Registers `java-expert` in TEMPLATES registry, updates test expectations and README

## Rule Files

| File | Topic |
|------|-------|
| `overview.md` | Core philosophy, project structure, definition of done |
| `modern-java.md` | Records, sealed classes, pattern matching, virtual threads, Optional, collections |
| `spring-boot.md` | REST controllers, services, configuration, security, health checks, profiles |
| `concurrency.md` | Virtual threads, structured concurrency, CompletableFuture, thread safety, channels |
| `persistence.md` | JPA entities, repositories, transactions, N+1 prevention, Flyway migrations, JDBC |
| `error-handling.md` | Exception hierarchy, validation, guard clauses, Result pattern, logging |
| `testing.md` | JUnit 5, AssertJ, Mockito, Testcontainers, WireMock, ArchUnit |
| `performance.md` | JFR, JMH, GC tuning, memory patterns, connection pooling, caching |
| `tooling.md` | Maven/Gradle, SpotBugs, ErrorProne, Checkstyle, Docker, CI/CD, logging |

## Test plan

- [x] All 94 tests pass
- [x] Template registered in TEMPLATES object (alphabetical order)
- [x] `expectedTemplates` array updated in test file
- [x] README template table updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)