### PR TITLE
feat(templates): add swift-expert template

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ npx agentic-team-templates --reset --force
 | `python-expert` | Principal-level Python engineering (type system, async, testing, FastAPI, Django) |
 | `qa-engineering` | Quality assurance programs for confident, rapid software delivery |
 | `rust-expert` | Principal-level Rust engineering (ownership, concurrency, unsafe, traits, async) |
+| `swift-expert` | Principal-level Swift engineering (concurrency, SwiftUI, protocols, testing, Apple platforms) |
 | `testing` | Comprehensive testing practices (TDD, test design, CI/CD integration, performance testing) |
 | `utility-agent` | AI agent utilities with context management and hallucination prevention |
 | `web-backend` | Backend APIs and services (REST, GraphQL, microservices) |

--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,10 @@ const TEMPLATES = {
     description: 'Principal-level Rust engineering (ownership, concurrency, unsafe, traits, async)',
     rules: ['concurrency.md', 'ecosystem-and-tooling.md', 'error-handling.md', 'overview.md', 'ownership-and-borrowing.md', 'performance-and-unsafe.md', 'testing.md', 'traits-and-generics.md']
   },
+  'swift-expert': {
+    description: 'Principal-level Swift engineering (concurrency, SwiftUI, protocols, testing, Apple platforms)',
+    rules: ['concurrency.md', 'error-handling.md', 'language-features.md', 'overview.md', 'performance.md', 'swiftui.md', 'testing.md', 'tooling.md']
+  },
   'testing': {
     description: 'Comprehensive testing practices (TDD, test design, CI/CD integration, performance testing)',
     rules: ['advanced-techniques.md', 'ci-cd-integration.md', 'overview.md', 'performance-testing.md', 'quality-metrics.md', 'reliability.md', 'tdd-methodology.md', 'test-data.md', 'test-design.md', 'test-types.md']

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -88,6 +88,7 @@ describe('Constants', () => {
         'python-expert',
         'qa-engineering',
         'rust-expert',
+        'swift-expert',
         'testing',
         'utility-agent',
         'web-backend',

--- a/templates/swift-expert/.cursorrules/concurrency.md
+++ b/templates/swift-expert/.cursorrules/concurrency.md
@@ -1,0 +1,230 @@
+# Swift Concurrency
+
+Structured concurrency with async/await, actors, and task groups. No more callback pyramids.
+
+## async/await
+
+```swift
+// Async functions
+func fetchUser(id: UUID) async throws -> User {
+    let (data, response) = try await urlSession.data(from: userURL(id))
+    guard let httpResponse = response as? HTTPURLResponse,
+          httpResponse.statusCode == 200 else {
+        throw APIError.invalidResponse
+    }
+    return try JSONDecoder().decode(User.self, from: data)
+}
+
+// Calling async code
+let user = try await fetchUser(id: userId)
+
+// Async let — parallel execution
+async let user = fetchUser(id: userId)
+async let orders = fetchOrders(userId: userId)
+async let preferences = fetchPreferences(userId: userId)
+
+let dashboard = try await Dashboard(
+    user: user,
+    orders: orders,
+    preferences: preferences
+)
+// All three requests run concurrently
+```
+
+## Task and TaskGroup
+
+```swift
+// Unstructured task (use sparingly)
+Task {
+    do {
+        let result = try await processData()
+        await MainActor.run { updateUI(with: result) }
+    } catch {
+        await MainActor.run { showError(error) }
+    }
+}
+
+// Task group — dynamic parallelism
+func fetchAllUsers(ids: [UUID]) async throws -> [User] {
+    try await withThrowingTaskGroup(of: User.self) { group in
+        for id in ids {
+            group.addTask {
+                try await fetchUser(id: id)
+            }
+        }
+
+        var users: [User] = []
+        for try await user in group {
+            users.append(user)
+        }
+        return users
+    }
+}
+
+// Task cancellation
+func longRunningProcess() async throws {
+    for item in items {
+        try Task.checkCancellation() // Throws if cancelled
+        await process(item)
+    }
+}
+
+// Cooperative cancellation
+Task {
+    let result = try await longRunningProcess()
+}
+// Later:
+task.cancel() // Cooperative — task must check
+```
+
+## Actors
+
+```swift
+// Actor — thread-safe mutable state
+actor ImageCache {
+    private var cache: [URL: UIImage] = [:]
+
+    func image(for url: URL) -> UIImage? {
+        cache[url]
+    }
+
+    func store(_ image: UIImage, for url: URL) {
+        cache[url] = image
+    }
+
+    func clear() {
+        cache.removeAll()
+    }
+}
+
+// Using actors
+let cache = ImageCache()
+let image = await cache.image(for: url) // await required for actor isolation
+
+// nonisolated — opt out for non-mutable access
+actor UserStore {
+    let id: UUID // Immutable, safe without isolation
+
+    nonisolated var description: String {
+        "UserStore(\(id))"
+    }
+}
+```
+
+## MainActor
+
+```swift
+// MainActor — UI thread safety
+@MainActor
+class UserViewModel: ObservableObject {
+    @Published var users: [User] = []
+    @Published var isLoading = false
+    @Published var error: AppError?
+
+    func loadUsers() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            users = try await userService.fetchAll()
+        } catch {
+            self.error = AppError(error)
+        }
+    }
+}
+
+// MainActor.run for one-off UI updates
+func processInBackground() async {
+    let result = await heavyComputation()
+    await MainActor.run {
+        self.displayResult = result
+    }
+}
+```
+
+## Sendable
+
+```swift
+// Sendable — safe to pass across concurrency domains
+struct UserDTO: Sendable {
+    let id: UUID
+    let name: String
+    let email: String
+}
+
+// @Sendable closures
+func performAsync(_ work: @Sendable @escaping () async -> Void) {
+    Task { await work() }
+}
+
+// @unchecked Sendable — manual safety guarantee
+final class ThreadSafeCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: Any] = [:]
+
+    func get(_ key: String) -> Any? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage[key]
+    }
+}
+```
+
+## AsyncSequence and AsyncStream
+
+```swift
+// AsyncStream for bridging callback APIs
+func notifications(named name: Notification.Name) -> AsyncStream<Notification> {
+    AsyncStream { continuation in
+        let observer = NotificationCenter.default.addObserver(
+            forName: name, object: nil, queue: nil
+        ) { notification in
+            continuation.yield(notification)
+        }
+        continuation.onTermination = { _ in
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+}
+
+// Consuming async sequences
+for await notification in notifications(named: .userDidLogin) {
+    handleLogin(notification)
+}
+
+// AsyncSequence transformations
+let validUsers = userStream
+    .filter { $0.isActive }
+    .map { UserViewModel(user: $0) }
+    .prefix(10)
+```
+
+## Rules
+
+- No `DispatchQueue.main.async` in new code — use `@MainActor` or `MainActor.run`
+- No completion handlers in new code — use `async`/`await`
+- No `DispatchGroup` — use `TaskGroup`
+- Always check `Task.isCancelled` or call `Task.checkCancellation()` in loops
+- Mark types as `Sendable` when passed across concurrency domains
+- Use actors for shared mutable state, not locks (in new code)
+- `Task {}` is unstructured — prefer structured concurrency (`async let`, `TaskGroup`)
+
+## Anti-Patterns
+
+```swift
+// Never: fire-and-forget tasks without error handling
+Task { try await riskyOperation() } // Errors silently swallowed
+// Use: Task with do/catch
+
+// Never: blocking the main thread
+DispatchQueue.main.sync { /* ... */ } // Deadlock risk
+// Use: @MainActor or MainActor.run
+
+// Never: capturing self strongly in long-lived tasks
+Task { [self] in await self.process() } // Potential retain cycle
+// Use: Task { [weak self] in await self?.process() }
+
+// Never: using GCD for new concurrent code
+DispatchQueue.global().async { /* ... */ }
+// Use: Task { /* ... */ } with async/await
+```

--- a/templates/swift-expert/.cursorrules/error-handling.md
+++ b/templates/swift-expert/.cursorrules/error-handling.md
@@ -1,0 +1,213 @@
+# Swift Error Handling
+
+Typed errors, Result, and defensive validation. Make failure states explicit.
+
+## Error Types
+
+```swift
+// Domain-specific errors with associated values
+enum APIError: Error, LocalizedError {
+    case networkUnavailable
+    case unauthorized
+    case notFound(resource: String, id: String)
+    case serverError(statusCode: Int, message: String)
+    case decodingFailed(type: String, underlying: Error)
+    case rateLimited(retryAfter: TimeInterval)
+
+    var errorDescription: String? {
+        switch self {
+        case .networkUnavailable:
+            "Network connection is unavailable"
+        case .unauthorized:
+            "Authentication required"
+        case .notFound(let resource, let id):
+            "\(resource) with ID '\(id)' not found"
+        case .serverError(let code, let message):
+            "Server error \(code): \(message)"
+        case .decodingFailed(let type, let error):
+            "Failed to decode \(type): \(error.localizedDescription)"
+        case .rateLimited(let retryAfter):
+            "Rate limited. Retry after \(retryAfter)s"
+        }
+    }
+}
+```
+
+## do/catch
+
+```swift
+// Specific error handling
+func loadUser(id: UUID) async {
+    do {
+        let user = try await userService.fetch(id: id)
+        self.user = user
+    } catch let error as APIError {
+        switch error {
+        case .notFound:
+            self.state = .notFound
+        case .unauthorized:
+            self.state = .needsLogin
+        case .networkUnavailable:
+            self.state = .offline
+        default:
+            self.state = .error(error)
+        }
+    } catch {
+        // Catch-all for unexpected errors
+        self.state = .error(AppError.unexpected(error))
+    }
+}
+
+// try? — convert to optional (use when failure is acceptable)
+let cachedImage = try? imageCache.load(key: url.absoluteString)
+
+// try! — only when failure is a programmer error
+let regex = try! NSRegularExpression(pattern: "^[a-z]+$")
+```
+
+## Result Type
+
+```swift
+// Result for synchronous operations
+func validate(email: String) -> Result<Email, ValidationError> {
+    guard !email.isEmpty else {
+        return .failure(.empty("email"))
+    }
+    guard email.contains("@") else {
+        return .failure(.invalidFormat("email"))
+    }
+    return .success(Email(rawValue: email))
+}
+
+// Pattern matching on Result
+switch validate(email: input) {
+case .success(let email):
+    createAccount(email: email)
+case .failure(let error):
+    showValidationError(error)
+}
+
+// Result with map/flatMap
+let userName = fetchUser(id: userId)
+    .map { $0.name }
+    .mapError { AppError.network($0) }
+```
+
+## Guard and Preconditions
+
+```swift
+// Guard — early exit for invalid state
+func processOrder(_ order: Order) throws {
+    guard order.items.isEmpty == false else {
+        throw OrderError.emptyOrder
+    }
+    guard order.status == .confirmed else {
+        throw OrderError.invalidStatus(order.status)
+    }
+    guard let paymentMethod = order.paymentMethod else {
+        throw OrderError.noPaymentMethod
+    }
+    // Happy path continues here, all values available
+    charge(paymentMethod, for: order)
+}
+
+// precondition — programmer errors (removed in -Ounchecked)
+func element(at index: Int) -> Element {
+    precondition(index >= 0 && index < count, "Index \(index) out of bounds")
+    return storage[index]
+}
+
+// assert — debug-only checks
+func configure(retryCount: Int) {
+    assert(retryCount > 0, "retryCount must be positive")
+    self.maxRetries = retryCount
+}
+
+// fatalError — truly impossible states
+func handle(_ state: AppState) {
+    switch state {
+    case .ready: start()
+    case .running: continue_()
+    // If new states are added, this will force handling them
+    @unknown default:
+        fatalError("Unhandled state: \(state)")
+    }
+}
+```
+
+## Typed Throws (Swift 6+)
+
+```swift
+// Typed throws — callers know exact error type
+func parse(json: Data) throws(ParseError) -> Config {
+    guard let dict = try? JSONSerialization.jsonObject(with: json) as? [String: Any] else {
+        throw .invalidJSON
+    }
+    guard let name = dict["name"] as? String else {
+        throw .missingField("name")
+    }
+    return Config(name: name)
+}
+
+// Caller gets typed error without casting
+do {
+    let config = try parse(json: data)
+} catch {
+    // error is ParseError, not any Error
+    switch error {
+    case .invalidJSON: handleInvalidJSON()
+    case .missingField(let name): handleMissingField(name)
+    }
+}
+```
+
+## Error Recovery Patterns
+
+```swift
+// Retry with exponential backoff
+func fetchWithRetry<T>(
+    maxAttempts: Int = 3,
+    operation: () async throws -> T
+) async throws -> T {
+    var lastError: Error?
+    for attempt in 0..<maxAttempts {
+        do {
+            return try await operation()
+        } catch {
+            lastError = error
+            if attempt < maxAttempts - 1 {
+                let delay = pow(2.0, Double(attempt))
+                try await Task.sleep(for: .seconds(delay))
+            }
+        }
+    }
+    throw lastError!
+}
+
+// Fallback chain
+func loadAvatar(for user: User) async -> UIImage {
+    if let cached = avatarCache[user.id] { return cached }
+    if let downloaded = try? await downloadAvatar(user.avatarURL) { return downloaded }
+    return UIImage(systemName: "person.circle")!
+}
+```
+
+## Anti-Patterns
+
+```swift
+// Never: catching and ignoring errors
+do { try operation() } catch { } // Silent failure
+// Use: at minimum, log the error
+
+// Never: using try! on fallible operations
+let data = try! Data(contentsOf: fileURL) // Crash on missing file
+// Use: do/try/catch or try? with fallback
+
+// Never: throwing generic Error
+throw NSError(domain: "", code: 0) // No context
+// Use: domain-specific error types
+
+// Never: error types without context
+enum AppError: Error { case failed } // Useless for debugging
+// Use: associated values with context
+```

--- a/templates/swift-expert/.cursorrules/language-features.md
+++ b/templates/swift-expert/.cursorrules/language-features.md
@@ -1,0 +1,246 @@
+# Swift Language Features
+
+Optionals, value types, enums, generics, and protocol-oriented design. The type system is your strongest tool.
+
+## Optionals
+
+```swift
+// Guard let — early exit pattern (preferred)
+guard let user = fetchUser(id: userId) else {
+    throw AppError.userNotFound(userId)
+}
+// user is non-optional from here
+
+// If let — conditional binding
+if let email = user.email {
+    sendNotification(to: email)
+}
+
+// Optional chaining
+let street = user.address?.street?.uppercased()
+
+// Nil coalescing
+let displayName = user.nickname ?? user.fullName ?? "Anonymous"
+
+// Optional map/flatMap
+let uppercasedEmail = user.email.map { $0.uppercased() }
+let parsed: URL? = urlString.flatMap { URL(string: $0) }
+
+// Never: force-unwrap without proof
+// user.email!  — use guard/if let instead
+// Only acceptable: IBOutlets (UIKit), known-safe literals
+let url = URL(string: "https://api.example.com")! // Known-safe literal
+```
+
+## Value Types vs Reference Types
+
+```swift
+// Prefer structs — value semantics, no shared mutable state
+struct User: Identifiable, Sendable {
+    let id: UUID
+    var name: String
+    var email: String
+    var preferences: Preferences
+}
+
+// Use classes only when you need:
+// 1. Identity (object === object)
+// 2. Reference semantics (shared state)
+// 3. Inheritance from ObjC classes
+// 4. Deinitializers
+class NetworkSession {
+    private var urlSession: URLSession
+    deinit { urlSession.invalidateAndCancel() }
+}
+
+// Copy-on-write for large value types
+struct LargeCollection<Element> {
+    private var storage: Storage // Reference type internally
+    // Implement COW manually only when profiling shows need
+}
+```
+
+## Enums
+
+```swift
+// Enums with associated values — model state precisely
+enum LoadingState<T> {
+    case idle
+    case loading
+    case loaded(T)
+    case failed(Error)
+}
+
+// Exhaustive switch — compiler enforces all cases
+func render(state: LoadingState<[User]>) -> some View {
+    switch state {
+    case .idle:
+        EmptyView()
+    case .loading:
+        ProgressView()
+    case .loaded(let users):
+        UserListView(users: users)
+    case .failed(let error):
+        ErrorView(error: error)
+    }
+    // No default needed — compiler verifies exhaustiveness
+}
+
+// String-backed enums for API
+enum UserRole: String, Codable, CaseIterable {
+    case admin
+    case editor
+    case viewer
+}
+
+// Enums as namespaces
+enum Constants {
+    static let maxRetries = 3
+    static let defaultTimeout: TimeInterval = 30
+}
+```
+
+## Protocols and Extensions
+
+```swift
+// Small, focused protocols
+protocol Identifiable {
+    associatedtype ID: Hashable
+    var id: ID { get }
+}
+
+protocol Displayable {
+    var displayName: String { get }
+}
+
+// Default implementations
+extension Displayable where Self: User {
+    var displayName: String { "\(firstName) \(lastName)" }
+}
+
+// Protocol composition
+func showProfile(for entity: Identifiable & Displayable) {
+    print("\(entity.id): \(entity.displayName)")
+}
+
+// Constrained extensions
+extension Array where Element: Numeric {
+    var sum: Element { reduce(0, +) }
+}
+
+extension Collection where Element: Identifiable {
+    func element(withId id: Element.ID) -> Element? {
+        first { $0.id == id }
+    }
+}
+```
+
+## Generics
+
+```swift
+// Generic functions
+func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+    try JSONDecoder().decode(type, from: data)
+}
+
+// Generic types with constraints
+struct Repository<Entity: Identifiable & Codable> {
+    private var storage: [Entity.ID: Entity] = [:]
+
+    mutating func save(_ entity: Entity) {
+        storage[entity.id] = entity
+    }
+
+    func find(by id: Entity.ID) -> Entity? {
+        storage[id]
+    }
+}
+
+// Opaque return types (some)
+func makeView() -> some View {
+    VStack {
+        Text("Hello")
+        Image(systemName: "star")
+    }
+}
+
+// Primary associated types (Swift 5.7+)
+func processCollection(_ items: some Collection<User>) { /* ... */ }
+```
+
+## Property Wrappers
+
+```swift
+// Standard property wrappers
+@Published var users: [User] = []
+@State private var isPresented = false
+@Binding var selectedTab: Tab
+@Environment(\.dismiss) var dismiss
+@AppStorage("darkMode") var isDarkMode = false
+
+// Custom property wrapper
+@propertyWrapper
+struct Clamped<Value: Comparable> {
+    private var value: Value
+    let range: ClosedRange<Value>
+
+    var wrappedValue: Value {
+        get { value }
+        set { value = min(max(newValue, range.lowerBound), range.upperBound) }
+    }
+
+    init(wrappedValue: Value, _ range: ClosedRange<Value>) {
+        self.range = range
+        self.value = min(max(wrappedValue, range.lowerBound), range.upperBound)
+    }
+}
+
+struct AudioSettings {
+    @Clamped(0...100) var volume: Int = 50
+}
+```
+
+## Result Builders
+
+```swift
+// SwiftUI uses @ViewBuilder
+@ViewBuilder
+func content(for state: LoadingState<User>) -> some View {
+    switch state {
+    case .loading:
+        ProgressView()
+    case .loaded(let user):
+        Text(user.name)
+    default:
+        EmptyView()
+    }
+}
+```
+
+## Anti-Patterns
+
+```swift
+// Never: force-unwrapping optionals carelessly
+let name = user.name!  // Crash if nil
+// Use: guard let name = user.name else { return }
+
+// Never: class where struct suffices
+class Point { var x: Double; var y: Double }
+// Use: struct Point { var x: Double; var y: Double }
+
+// Never: stringly-typed APIs
+func fetchData(endpoint: String) { /* ... */ }
+// Use: enum Endpoint { case users; case orders }
+
+// Never: Any/AnyObject without cause
+func process(_ items: [Any]) { /* ... */ }
+// Use: generics or protocols
+
+// Never: deeply nested if/let chains
+if let a = optionalA {
+    if let b = a.optionalB {
+        if let c = b.optionalC { /* ... */ }
+    }
+}
+// Use: guard let with early return, or optional chaining
+```

--- a/templates/swift-expert/.cursorrules/overview.md
+++ b/templates/swift-expert/.cursorrules/overview.md
@@ -1,0 +1,88 @@
+# Swift Expert Overview
+
+Principal-level Swift engineering. Deep language mastery, protocol-oriented design, concurrency, and Apple platform expertise.
+
+## Scope
+
+This guide applies to:
+- iOS and iPadOS applications (UIKit, SwiftUI)
+- macOS applications (AppKit, SwiftUI)
+- watchOS and tvOS applications
+- Server-side Swift (Vapor, Hummingbird)
+- Swift packages and frameworks
+- Command-line tools
+
+## Core Philosophy
+
+Swift is a safe, fast, and expressive language. Use its type system to make invalid states unrepresentable.
+
+- **Safety is the foundation.** Optionals, value types, and the compiler are your first line of defense
+- **Protocol-oriented design.** Prefer protocols and composition over class inheritance
+- **Value semantics by default.** Structs over classes unless you need reference semantics
+- **Concurrency is structured.** async/await, actors, and task groups — not GCD callbacks
+- **Expressiveness without obscurity.** Clear is better than clever
+- **If you don't know, say so.** Admitting uncertainty is professional
+
+## Key Principles
+
+1. **Optionals Are Not Enemies** — Embrace `Optional`. Never force-unwrap without proof. Use `guard`, `if let`, `map`, `flatMap`
+2. **Value Types by Default** — Structs, enums, tuples. Classes only when identity or reference semantics are required
+3. **Protocol-Oriented Design** — Small, focused protocols. Default implementations via extensions. Composition over inheritance
+4. **Structured Concurrency** — `async`/`await`, `TaskGroup`, actors. No completion handler callbacks in new code
+5. **Exhaustive Pattern Matching** — `switch` on enums is exhaustive. The compiler enforces completeness
+
+## Project Structure
+
+```
+MyApp/
+├── Sources/
+│   ├── App/
+│   │   ├── MyAppApp.swift
+│   │   └── AppDelegate.swift
+│   ├── Features/
+│   │   ├── Auth/
+│   │   │   ├── Views/
+│   │   │   ├── ViewModels/
+│   │   │   └── Models/
+│   │   └── Home/
+│   ├── Core/
+│   │   ├── Networking/
+│   │   ├── Persistence/
+│   │   └── Extensions/
+│   └── Shared/
+│       ├── Components/
+│       └── Utilities/
+├── Tests/
+│   ├── UnitTests/
+│   ├── IntegrationTests/
+│   └── UITests/
+├── Package.swift (or .xcodeproj)
+└── README.md
+```
+
+## API Design Guidelines
+
+Follow Swift's official API Design Guidelines:
+
+- **Clarity at the point of use** is the most important goal
+- **Omit needless words** — every word should convey information
+- **Name according to roles**, not types: `let greeting: String` not `let greetingString: String`
+- **Label closure parameters**: `func filter(_ isIncluded: (Element) -> Bool)`
+- **Boolean properties** read as assertions: `isEmpty`, `hasChildren`, `canBecomeFirstResponder`
+- **Mutating/nonmutating pairs**: `sort()`/`sorted()`, `append()`/`appending()`
+- **Protocols describing capabilities** end in `-able`, `-ible`, or `-ing`: `Equatable`, `Codable`, `Sendable`
+
+## Definition of Done
+
+A Swift feature is complete when:
+
+- [ ] Compiles with zero warnings
+- [ ] All tests pass (unit + UI)
+- [ ] No force-unwraps (`!`) without documented justification
+- [ ] No `var` where `let` suffices
+- [ ] Proper access control (`private`, `internal`, `public`)
+- [ ] Concurrency code uses structured concurrency (no raw GCD in new code)
+- [ ] SwiftLint reports zero violations
+- [ ] No retain cycles (weak/unowned references verified)
+- [ ] Accessibility labels on all interactive UI elements
+- [ ] Code reviewed and approved

--- a/templates/swift-expert/.cursorrules/performance.md
+++ b/templates/swift-expert/.cursorrules/performance.md
@@ -1,0 +1,260 @@
+# Swift Performance
+
+Profile first. Understand ARC, value types, and Instruments. Optimize what matters.
+
+## Profile Before Optimizing
+
+```bash
+# Instruments — always profile before optimizing
+# Time Profiler: CPU hotspots
+# Allocations: memory usage and leaks
+# Leaks: retain cycles
+# Network: request analysis
+# Core Animation: rendering performance
+
+# Xcode: Product → Profile (⌘I)
+```
+
+## Value Types and Copy-on-Write
+
+```swift
+// Structs are stack-allocated (when possible) and value-copied
+// But Swift uses COW for standard library collections
+var array1 = [1, 2, 3]
+var array2 = array1 // No copy yet — shared storage
+array2.append(4)    // Copy happens here (COW trigger)
+
+// Custom COW for large value types
+struct LargeStruct {
+    private final class Storage {
+        var data: [Int]
+        init(data: [Int]) { self.data = data }
+    }
+
+    private var storage: Storage
+
+    var data: [Int] {
+        get { storage.data }
+        set {
+            if !isKnownUniquelyReferenced(&storage) {
+                storage = Storage(data: newValue)
+            } else {
+                storage.data = newValue
+            }
+        }
+    }
+}
+```
+
+## ARC and Retain Cycles
+
+```swift
+// Weak references — break retain cycles
+class ViewController: UIViewController {
+    private var cancellable: AnyCancellable?
+
+    func subscribe() {
+        cancellable = publisher
+            .sink { [weak self] value in  // weak self!
+                self?.handleValue(value)
+            }
+    }
+}
+
+// Unowned — when you guarantee the reference outlives the closure
+class Parent {
+    let child: Child
+
+    init() {
+        child = Child()
+        child.onComplete = { [unowned self] in
+            self.handleCompletion() // Crashes if self is deallocated
+        }
+    }
+}
+
+// Capture lists — be explicit
+Task { [weak self, userId = self.user.id] in
+    guard let self else { return }
+    let data = try await self.fetch(userId: userId)
+}
+```
+
+## Collection Performance
+
+```swift
+// Reserve capacity for known sizes
+var results: [ProcessedItem] = []
+results.reserveCapacity(items.count)
+
+// Use lazy for chained operations on large collections
+let names = users.lazy
+    .filter { $0.isActive }
+    .map { $0.fullName }
+    .prefix(10)
+// Operations only execute when iterated
+
+// ContiguousArray for non-class element types
+let numbers = ContiguousArray<Int>(repeating: 0, count: 1000)
+// Guaranteed contiguous memory layout — better cache performance
+
+// Set for membership tests
+let activeIds = Set(activeUsers.map(\.id)) // O(1) lookup
+let filtered = orders.filter { activeIds.contains($0.userId) }
+
+// Dictionary for keyed access
+let userById = Dictionary(uniqueKeysWithValues: users.map { ($0.id, $0) })
+```
+
+## String Performance
+
+```swift
+// String is a value type with COW
+// UTF-8 encoded internally — character access is O(n)
+
+// Prefer Substring over creating new Strings
+let greeting = "Hello, World!"
+let hello = greeting.prefix(5) // Substring — shares storage
+
+// Convert to String only when needed for storage
+let stored = String(hello) // Creates independent copy
+
+// Use string interpolation — optimized by compiler
+let message = "User \(user.name) logged in" // Efficient
+
+// For heavy concatenation
+var result = ""
+result.reserveCapacity(estimatedLength)
+for item in items {
+    result += item.description
+}
+```
+
+## SwiftUI Performance
+
+```swift
+// Avoid unnecessary view recomputation
+struct UserRow: View {
+    let user: User // Prefer let over @State for display-only data
+
+    var body: some View {
+        HStack {
+            AvatarView(url: user.avatarURL)
+            Text(user.name)
+        }
+    }
+}
+
+// Equatable conformance to skip redundant diffs
+struct ExpensiveView: View, Equatable {
+    let data: ChartData
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.data.id == rhs.data.id && lhs.data.version == rhs.data.version
+    }
+
+    var body: some View {
+        ChartRenderer(data: data) // Expensive
+    }
+}
+
+// Use @Observable over ObservableObject (iOS 17+)
+// @Observable tracks property-level access — fewer view updates
+
+// Lazy stacks for large lists
+ScrollView {
+    LazyVStack { // Only creates visible views
+        ForEach(items) { item in
+            ItemRow(item: item)
+        }
+    }
+}
+```
+
+## Concurrency Performance
+
+```swift
+// Limit concurrent work
+func processImages(_ urls: [URL]) async throws -> [UIImage] {
+    try await withThrowingTaskGroup(of: UIImage.self) { group in
+        let maxConcurrency = ProcessInfo.processInfo.activeProcessorCount
+
+        var results: [UIImage] = []
+        results.reserveCapacity(urls.count)
+
+        for (index, url) in urls.enumerated() {
+            if index >= maxConcurrency {
+                if let image = try await group.next() {
+                    results.append(image)
+                }
+            }
+            group.addTask { try await downloadImage(from: url) }
+        }
+
+        for try await image in group {
+            results.append(image)
+        }
+        return results
+    }
+}
+
+// Avoid unnecessary actor hops
+actor DataStore {
+    private var items: [Item] = []
+
+    // Batch operations reduce actor hops
+    func addAll(_ newItems: [Item]) {
+        items.append(contentsOf: newItems) // Single hop
+    }
+    // Instead of calling add(_:) in a loop — one hop per call
+}
+```
+
+## Memory Management
+
+```swift
+// Autoreleasepool for tight loops with ObjC objects
+func processLargeDataset() {
+    for batch in dataset.chunks(ofCount: 100) {
+        autoreleasepool {
+            let processed = batch.map { transform($0) }
+            save(processed)
+        }
+        // Memory released each iteration
+    }
+}
+
+// Avoid strong reference cycles in closures
+class NetworkManager {
+    var onComplete: ((Result<Data, Error>) -> Void)?
+
+    deinit {
+        onComplete = nil // Break cycle on dealloc
+    }
+}
+```
+
+## Anti-Patterns
+
+```swift
+// Never: premature optimization without profiling
+// "I think this allocation is slow" — prove it with Instruments
+
+// Never: using classes where structs work
+class Point { var x: Double; var y: Double } // Heap allocation
+// Use: struct Point — stack allocation, no ARC overhead
+
+// Never: force-unwrapping in hot paths
+array[index]! // Hidden crash waiting to happen
+
+// Never: string concatenation with + in loops
+var result = ""
+for item in items { result = result + item.name } // O(n²)
+// Use: reserveCapacity + append, or joined()
+
+// Never: capturing self strongly in long-lived closures
+timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+    self.update() // Retain cycle
+}
+// Use: [weak self]
+```

--- a/templates/swift-expert/.cursorrules/swiftui.md
+++ b/templates/swift-expert/.cursorrules/swiftui.md
@@ -1,0 +1,260 @@
+# SwiftUI
+
+Declarative UI with composable views, state management, and the observation framework.
+
+## View Fundamentals
+
+```swift
+struct UserProfileView: View {
+    let user: User
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            AsyncImage(url: user.avatarURL) { image in
+                image.resizable().scaledToFill()
+            } placeholder: {
+                ProgressView()
+            }
+            .frame(width: 80, height: 80)
+            .clipShape(Circle())
+
+            Text(user.name)
+                .font(.title2)
+                .fontWeight(.bold)
+
+            Text(user.bio)
+                .font(.body)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+    }
+}
+```
+
+## State Management
+
+```swift
+// @State — view-local mutable state (value types)
+struct CounterView: View {
+    @State private var count = 0
+
+    var body: some View {
+        Button("Count: \(count)") { count += 1 }
+    }
+}
+
+// @Binding — two-way connection to parent's state
+struct ToggleRow: View {
+    let title: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        Toggle(title, isOn: $isOn)
+    }
+}
+
+// @StateObject — owned reference type (create once)
+struct UserListView: View {
+    @StateObject private var viewModel = UserListViewModel()
+
+    var body: some View {
+        List(viewModel.users) { user in
+            UserRow(user: user)
+        }
+        .task { await viewModel.loadUsers() }
+    }
+}
+
+// @ObservedObject — non-owned reference type (passed in)
+struct UserDetailView: View {
+    @ObservedObject var viewModel: UserDetailViewModel
+    // ...
+}
+
+// @EnvironmentObject — shared dependency via environment
+struct SettingsView: View {
+    @EnvironmentObject var theme: ThemeManager
+    // ...
+}
+```
+
+## Observation Framework (iOS 17+)
+
+```swift
+// @Observable replaces ObservableObject
+@Observable
+class UserViewModel {
+    var users: [User] = []
+    var isLoading = false
+    var error: AppError?
+
+    func loadUsers() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            users = try await userService.fetchAll()
+        } catch {
+            self.error = AppError(error)
+        }
+    }
+}
+
+// No @Published needed. SwiftUI tracks property access automatically
+struct UserListView: View {
+    var viewModel = UserViewModel()
+
+    var body: some View {
+        List(viewModel.users) { user in
+            Text(user.name)
+        }
+        .overlay { if viewModel.isLoading { ProgressView() } }
+        .task { await viewModel.loadUsers() }
+    }
+}
+```
+
+## Navigation
+
+```swift
+// NavigationStack with type-safe routing
+enum Route: Hashable {
+    case userDetail(User)
+    case settings
+    case editProfile
+}
+
+struct ContentView: View {
+    @State private var path = NavigationPath()
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            HomeView()
+                .navigationDestination(for: Route.self) { route in
+                    switch route {
+                    case .userDetail(let user):
+                        UserDetailView(user: user)
+                    case .settings:
+                        SettingsView()
+                    case .editProfile:
+                        EditProfileView()
+                    }
+                }
+        }
+    }
+}
+```
+
+## Composition Patterns
+
+```swift
+// Small, composable views
+struct AvatarView: View {
+    let url: URL?
+    var size: CGFloat = 40
+
+    var body: some View {
+        AsyncImage(url: url) { image in
+            image.resizable().scaledToFill()
+        } placeholder: {
+            Image(systemName: "person.circle.fill")
+                .foregroundStyle(.secondary)
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+    }
+}
+
+// ViewModifier for reusable styling
+struct CardModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding()
+            .background(.background)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .shadow(radius: 2)
+    }
+}
+
+extension View {
+    func cardStyle() -> some View {
+        modifier(CardModifier())
+    }
+}
+
+// Usage: Text("Hello").cardStyle()
+```
+
+## Lists and Performance
+
+```swift
+// Lazy loading
+struct UserListView: View {
+    let users: [User]
+
+    var body: some View {
+        List {
+            ForEach(users) { user in
+                UserRow(user: user)
+            }
+        }
+        .listStyle(.plain)
+    }
+}
+
+// LazyVStack for custom layouts
+ScrollView {
+    LazyVStack(spacing: 8) {
+        ForEach(items) { item in
+            ItemView(item: item) // Only created when visible
+        }
+    }
+}
+```
+
+## Previews
+
+```swift
+#Preview("User Profile") {
+    UserProfileView(user: .preview)
+        .padding()
+}
+
+#Preview("Loading State") {
+    UserProfileView(user: .preview)
+        .redacted(reason: .placeholder)
+}
+
+// Preview data
+extension User {
+    static var preview: User {
+        User(id: UUID(), name: "Jane Doe", email: "jane@example.com")
+    }
+}
+```
+
+## Anti-Patterns
+
+```swift
+// Never: massive body properties
+var body: some View {
+    // 200 lines of nested views
+}
+// Use: extract subviews as separate structs or computed properties
+
+// Never: business logic in views
+var body: some View {
+    Button("Submit") {
+        let valid = email.contains("@") && password.count >= 8
+        if valid { /* ... */ }
+    }
+}
+// Use: view model with dedicated validation
+
+// Never: @ObservedObject for view-created objects
+@ObservedObject var vm = MyViewModel() // Recreated on every view update!
+// Use: @StateObject for view-owned objects
+
+// Never: ignoring .task lifecycle
+.onAppear { Task { await load() } } // No automatic cancellation
+// Use: .task { await load() } — cancelled when view disappears
+```

--- a/templates/swift-expert/.cursorrules/testing.md
+++ b/templates/swift-expert/.cursorrules/testing.md
@@ -1,0 +1,286 @@
+# Swift Testing
+
+XCTest, Swift Testing framework, and UI testing. Test behavior with expressive assertions.
+
+## Framework Stack
+
+| Tool | Purpose |
+|------|---------|
+| Swift Testing | Modern test framework (Swift 5.10+) |
+| XCTest | Traditional test framework |
+| ViewInspector | SwiftUI view testing |
+| XCUITest | UI automation testing |
+| swift-snapshot-testing | Snapshot/screenshot testing |
+| OHHTTPStubs / URLProtocol | Network mocking |
+
+## Swift Testing Framework
+
+```swift
+import Testing
+
+@Suite("UserService")
+struct UserServiceTests {
+    let sut: UserService
+    let mockRepo: MockUserRepository
+
+    init() {
+        mockRepo = MockUserRepository()
+        sut = UserService(repository: mockRepo)
+    }
+
+    @Test("creates user with valid input")
+    func createUserValid() async throws {
+        let request = CreateUserRequest(name: "Alice", email: "alice@test.com")
+
+        let user = try await sut.create(request)
+
+        #expect(user.name == "Alice")
+        #expect(user.email == "alice@test.com")
+        #expect(user.id != UUID())
+    }
+
+    @Test("rejects duplicate email")
+    func rejectsDuplicateEmail() async {
+        mockRepo.existingEmails = ["alice@test.com"]
+        let request = CreateUserRequest(name: "Alice", email: "alice@test.com")
+
+        await #expect(throws: ValidationError.duplicateEmail) {
+            try await sut.create(request)
+        }
+    }
+
+    @Test("validates email format", arguments: [
+        "invalid",
+        "@missing.local",
+        "no-at-sign",
+        "",
+    ])
+    func invalidEmails(email: String) async {
+        let request = CreateUserRequest(name: "Test", email: email)
+
+        await #expect(throws: ValidationError.invalidEmail) {
+            try await sut.create(request)
+        }
+    }
+}
+```
+
+## XCTest (Traditional)
+
+```swift
+final class OrderServiceTests: XCTestCase {
+    private var sut: OrderService!
+    private var mockInventory: MockInventoryClient!
+
+    override func setUp() {
+        super.setUp()
+        mockInventory = MockInventoryClient()
+        sut = OrderService(inventory: mockInventory)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockInventory = nil
+        super.tearDown()
+    }
+
+    func test_createOrder_withValidItems_succeeds() async throws {
+        // Arrange
+        mockInventory.availableStock = ["SKU-001": 10]
+        let request = CreateOrderRequest(items: [.init(sku: "SKU-001", quantity: 2)])
+
+        // Act
+        let order = try await sut.create(request)
+
+        // Assert
+        XCTAssertEqual(order.items.count, 1)
+        XCTAssertEqual(order.status, .pending)
+        XCTAssertEqual(mockInventory.reserveCalls.count, 1)
+    }
+
+    func test_createOrder_withInsufficientStock_throws() async {
+        mockInventory.availableStock = ["SKU-001": 0]
+        let request = CreateOrderRequest(items: [.init(sku: "SKU-001", quantity: 5)])
+
+        do {
+            _ = try await sut.create(request)
+            XCTFail("Expected OrderError.insufficientStock")
+        } catch let error as OrderError {
+            XCTAssertEqual(error, .insufficientStock("SKU-001"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}
+```
+
+## Async Testing
+
+```swift
+// Swift Testing — async is native
+@Test func fetchUsers() async throws {
+    let users = try await sut.fetchAll()
+    #expect(users.count == 3)
+}
+
+// XCTest — async/await support
+func test_fetchUsers() async throws {
+    let users = try await sut.fetchAll()
+    XCTAssertEqual(users.count, 3)
+}
+
+// Testing with timeouts (XCTest)
+func test_longRunningOperation() async throws {
+    let expectation = expectation(description: "completes")
+
+    Task {
+        _ = try await sut.processLargeDataset()
+        expectation.fulfill()
+    }
+
+    await fulfillment(of: [expectation], timeout: 10)
+}
+```
+
+## Mocking with Protocols
+
+```swift
+// Protocol-based dependency
+protocol UserRepository {
+    func findById(_ id: UUID) async throws -> User?
+    func save(_ user: User) async throws -> User
+    func delete(_ id: UUID) async throws
+}
+
+// Mock implementation
+final class MockUserRepository: UserRepository {
+    var users: [UUID: User] = [:]
+    var saveCalls: [User] = []
+    var deleteCalls: [UUID] = []
+    var findByIdError: Error?
+
+    func findById(_ id: UUID) async throws -> User? {
+        if let error = findByIdError { throw error }
+        return users[id]
+    }
+
+    func save(_ user: User) async throws -> User {
+        saveCalls.append(user)
+        users[user.id] = user
+        return user
+    }
+
+    func delete(_ id: UUID) async throws {
+        deleteCalls.append(id)
+        users.removeValue(forKey: id)
+    }
+}
+```
+
+## Network Mocking
+
+```swift
+// URLProtocol-based mock
+class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            fatalError("requestHandler not set")
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// Usage in tests
+func test_fetchUser_decodesResponse() async throws {
+    let userData = try JSONEncoder().encode(User.preview)
+    MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, userData)
+    }
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+    let client = APIClient(session: session)
+
+    let user = try await client.fetchUser(id: UUID())
+    XCTAssertEqual(user.name, "Jane Doe")
+}
+```
+
+## UI Testing
+
+```swift
+final class LoginUITests: XCTestCase {
+    let app = XCUIApplication()
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        app.launchArguments = ["--uitesting"]
+        app.launch()
+    }
+
+    func test_loginFlow_withValidCredentials() {
+        let emailField = app.textFields["email-field"]
+        emailField.tap()
+        emailField.typeText("user@test.com")
+
+        let passwordField = app.secureTextFields["password-field"]
+        passwordField.tap()
+        passwordField.typeText("password123")
+
+        app.buttons["login-button"].tap()
+
+        XCTAssertTrue(app.staticTexts["welcome-label"].waitForExistence(timeout: 5))
+    }
+}
+```
+
+## Test Naming
+
+```swift
+// XCTest: test_[method]_[condition]_[expected]
+func test_validate_emptyEmail_throwsValidationError()
+func test_create_validRequest_returnsNewUser()
+func test_delete_nonexistentUser_throwsNotFound()
+
+// Swift Testing: descriptive strings
+@Test("validates email format rejects empty string")
+@Test("creates user with all required fields")
+@Test("deletes existing user successfully")
+```
+
+## Anti-Patterns
+
+```swift
+// Never: testing implementation details
+XCTAssertEqual(viewModel.fetchCallCount, 1) // Fragile
+// Test the observable outcome instead
+
+// Never: shared mutable state between tests
+static var sharedDatabase = Database() // Tests affect each other
+// Use: setUp/tearDown for fresh state
+
+// Never: testing with real network calls
+let user = try await realAPIClient.fetchUser(id: uuid) // Flaky
+// Use: protocol mocking or URLProtocol
+
+// Never: sleeping in tests
+try await Task.sleep(for: .seconds(2)) // Slow and flaky
+// Use: expectations with timeouts, or test schedulers
+```

--- a/templates/swift-expert/.cursorrules/tooling.md
+++ b/templates/swift-expert/.cursorrules/tooling.md
@@ -1,0 +1,285 @@
+# Swift Tooling and Build System
+
+Swift Package Manager, Xcode, static analysis, and CI/CD pipelines.
+
+## Swift Package Manager
+
+```swift
+// Package.swift
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MyApp",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "MyAppCore", targets: ["MyAppCore"]),
+        .executable(name: "MyAppCLI", targets: ["MyAppCLI"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-log", from: "1.5.0"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.15.0"),
+    ],
+    targets: [
+        .target(
+            name: "MyAppCore",
+            dependencies: [
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        ),
+        .executableTarget(
+            name: "MyAppCLI",
+            dependencies: [
+                "MyAppCore",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+        .testTarget(
+            name: "MyAppCoreTests",
+            dependencies: [
+                "MyAppCore",
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+            ]
+        ),
+    ]
+)
+```
+
+## Essential Commands
+
+```bash
+# Build
+swift build                          # Debug build
+swift build -c release               # Release build
+xcodebuild -scheme MyApp build       # Xcode build
+
+# Test
+swift test                           # Run all tests
+swift test --filter UserServiceTests # Run specific suite
+xcodebuild test -scheme MyApp \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+
+# Run
+swift run MyAppCLI                   # Run executable target
+swift run MyAppCLI -- --help         # Pass arguments
+
+# Dependencies
+swift package resolve                # Resolve dependencies
+swift package update                 # Update to latest compatible
+swift package show-dependencies      # Dependency tree
+
+# Format and lint
+swift format . --recursive           # swift-format
+swiftlint                           # SwiftLint analysis
+swiftlint --fix                     # Auto-fix violations
+```
+
+## SwiftLint
+
+```yaml
+# .swiftlint.yml
+opt_in_rules:
+  - empty_count
+  - closure_spacing
+  - contains_over_filter_count
+  - discouraged_optional_boolean
+  - explicit_init
+  - fatal_error_message
+  - first_where
+  - force_unwrapping
+  - implicit_return
+  - joined_default_parameter
+  - last_where
+  - overridden_super_call
+  - private_action
+  - private_outlet
+  - redundant_nil_coalescing
+  - sorted_first_last
+  - unowned_variable_capture
+  - vertical_whitespace_closing_braces
+
+disabled_rules:
+  - trailing_comma
+
+force_cast: error
+force_try: error
+force_unwrapping: warning
+
+line_length:
+  warning: 120
+  error: 200
+
+type_body_length:
+  warning: 300
+  error: 500
+
+file_length:
+  warning: 500
+  error: 1000
+
+function_body_length:
+  warning: 40
+  error: 80
+
+excluded:
+  - Pods
+  - .build
+  - DerivedData
+```
+
+## Xcode Project Configuration
+
+```
+Build Settings (recommended):
+- SWIFT_STRICT_CONCURRENCY = complete    # Full Sendable checking
+- SWIFT_VERSION = 6.0
+- ENABLE_STRICT_OBJC_MSGSEND = YES
+- GCC_TREAT_WARNINGS_AS_ERRORS = YES     # Zero-warning policy
+- SWIFT_TREAT_WARNINGS_AS_ERRORS = YES
+```
+
+## CI/CD (GitHub Actions)
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.0.app
+
+      - name: Build
+        run: |
+          xcodebuild build \
+            -scheme MyApp \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -skipPackagePluginValidation
+
+      - name: Test
+        run: |
+          xcodebuild test \
+            -scheme MyApp \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -resultBundlePath TestResults.xcresult \
+            -skipPackagePluginValidation
+
+      - name: SwiftLint
+        run: |
+          brew install swiftlint
+          swiftlint --strict
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults.xcresult
+
+  # SPM-only projects
+  spm-test:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.0.app
+      - name: Build and test
+        run: swift test --parallel
+```
+
+## Logging
+
+```swift
+import os
+
+// Unified logging (Apple platforms)
+private let logger = Logger(subsystem: "com.example.myapp", category: "networking")
+
+logger.info("Fetching user \(userId, privacy: .public)")
+logger.debug("Response: \(data.count) bytes")
+logger.error("Request failed: \(error.localizedDescription, privacy: .public)")
+
+// Log levels: debug, info, notice, error, fault
+// debug/info are not persisted by default — minimal performance cost
+
+// swift-log (cross-platform / server)
+import Logging
+
+var logger = Logger(label: "com.example.myapp")
+logger[metadataKey: "requestId"] = "\(requestId)"
+logger.info("Processing request", metadata: ["userId": "\(userId)"])
+```
+
+## Networking (URLSession)
+
+```swift
+// Modern URLSession with async/await
+actor APIClient {
+    private let session: URLSession
+    private let decoder: JSONDecoder
+
+    init(session: URLSession = .shared) {
+        self.session = session
+        self.decoder = JSONDecoder()
+        self.decoder.dateDecodingStrategy = .iso8601
+        self.decoder.keyDecodingStrategy = .convertFromSnakeCase
+    }
+
+    func request<T: Decodable>(_ endpoint: Endpoint) async throws -> T {
+        var request = URLRequest(url: endpoint.url)
+        request.httpMethod = endpoint.method.rawValue
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let body = endpoint.body {
+            request.httpBody = try JSONEncoder().encode(body)
+        }
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw APIError.serverError(
+                statusCode: httpResponse.statusCode,
+                message: String(data: data, encoding: .utf8) ?? ""
+            )
+        }
+
+        return try decoder.decode(T.self, from: data)
+    }
+}
+```
+
+## Anti-Patterns
+
+```swift
+// Never: print() for logging in production
+print("User logged in: \(user.id)") // No levels, no filtering, stdout only
+// Use: os.Logger or swift-log
+
+// Never: ignoring SwiftLint in CI
+// Static analysis catches real bugs and code smells
+
+// Never: hardcoded strings for UI
+Text("Welcome back!") // Not localizable
+// Use: String(localized: "welcome_back")
+
+// Never: Cocoapods for new projects (when SPM works)
+// SPM is the standard. Use Cocoapods only for libraries without SPM support
+```

--- a/templates/swift-expert/CLAUDE.md
+++ b/templates/swift-expert/CLAUDE.md
@@ -1,0 +1,275 @@
+# Swift Expert Development Guide
+
+Principal-level guidelines for Swift engineering. Deep language mastery, structured concurrency, SwiftUI, protocol-oriented design, and Apple platform expertise.
+
+---
+
+## Overview
+
+This guide applies to:
+- iOS and iPadOS applications (UIKit, SwiftUI)
+- macOS applications (AppKit, SwiftUI)
+- watchOS and tvOS applications
+- Server-side Swift (Vapor, Hummingbird)
+- Swift packages and frameworks
+- Command-line tools
+
+### Core Philosophy
+
+Swift is a safe, fast, and expressive language. Use its type system to make invalid states unrepresentable.
+
+- **Safety is the foundation.** Optionals, value types, and the compiler are your first line of defense
+- **Protocol-oriented design.** Prefer protocols and composition over class inheritance
+- **Value semantics by default.** Structs over classes unless you need reference semantics
+- **Concurrency is structured.** async/await, actors, and task groups — not GCD callbacks
+- **Expressiveness without obscurity.** Clear is better than clever
+- **If you don't know, say so.** Admitting uncertainty is professional
+
+### Key Principles
+
+1. **Optionals Are Not Enemies** — Embrace `Optional`. Never force-unwrap without proof
+2. **Value Types by Default** — Structs, enums, tuples. Classes only when identity or reference semantics are required
+3. **Protocol-Oriented Design** — Small, focused protocols. Composition over inheritance
+4. **Structured Concurrency** — `async`/`await`, `TaskGroup`, actors. No completion handler callbacks in new code
+5. **Exhaustive Pattern Matching** — `switch` on enums is exhaustive. The compiler enforces completeness
+
+### Project Structure
+
+```
+MyApp/
+├── Sources/
+│   ├── App/
+│   ├── Features/
+│   │   ├── Auth/
+│   │   └── Home/
+│   ├── Core/
+│   │   ├── Networking/
+│   │   ├── Persistence/
+│   │   └── Extensions/
+│   └── Shared/
+├── Tests/
+├── Package.swift
+└── README.md
+```
+
+---
+
+## Language Features
+
+### Optionals
+
+```swift
+guard let user = fetchUser(id: userId) else { throw AppError.userNotFound(userId) }
+let displayName = user.nickname ?? user.fullName ?? "Anonymous"
+let uppercasedEmail = user.email.map { $0.uppercased() }
+// Never: user.email! — use guard/if let instead
+```
+
+### Value Types and Enums
+
+```swift
+struct User: Identifiable, Sendable {
+    let id: UUID
+    var name: String
+    var email: String
+}
+
+enum LoadingState<T> {
+    case idle, loading, loaded(T), failed(Error)
+}
+```
+
+### Protocols and Extensions
+
+```swift
+protocol Displayable {
+    var displayName: String { get }
+}
+
+extension Collection where Element: Identifiable {
+    func element(withId id: Element.ID) -> Element? {
+        first { $0.id == id }
+    }
+}
+```
+
+---
+
+## Concurrency
+
+### async/await
+
+```swift
+func fetchDashboard(userId: UUID) async throws -> Dashboard {
+    async let user = fetchUser(id: userId)
+    async let orders = fetchOrders(userId: userId)
+    return try await Dashboard(user: user, orders: orders)
+}
+```
+
+### Actors
+
+```swift
+actor ImageCache {
+    private var cache: [URL: UIImage] = [:]
+    func image(for url: URL) -> UIImage? { cache[url] }
+    func store(_ image: UIImage, for url: URL) { cache[url] = image }
+}
+```
+
+### Rules
+
+- No `DispatchQueue.main.async` in new code — use `@MainActor`
+- No completion handlers in new code — use `async`/`await`
+- Always check `Task.isCancelled` in loops
+- Use actors for shared mutable state
+
+---
+
+## Error Handling
+
+### Error Types
+
+```swift
+enum APIError: Error, LocalizedError {
+    case networkUnavailable
+    case notFound(resource: String, id: String)
+    case serverError(statusCode: Int, message: String)
+}
+```
+
+### Guard Pattern
+
+```swift
+func processOrder(_ order: Order) throws {
+    guard !order.items.isEmpty else { throw OrderError.emptyOrder }
+    guard order.status == .confirmed else { throw OrderError.invalidStatus(order.status) }
+    guard let payment = order.paymentMethod else { throw OrderError.noPaymentMethod }
+    charge(payment, for: order)
+}
+```
+
+---
+
+## SwiftUI
+
+### State Management
+
+```swift
+@Observable
+class UserViewModel {
+    var users: [User] = []
+    var isLoading = false
+
+    func loadUsers() async {
+        isLoading = true
+        defer { isLoading = false }
+        users = (try? await userService.fetchAll()) ?? []
+    }
+}
+```
+
+### Navigation
+
+```swift
+enum Route: Hashable {
+    case userDetail(User)
+    case settings
+}
+
+NavigationStack(path: $path) {
+    HomeView()
+        .navigationDestination(for: Route.self) { route in
+            switch route {
+            case .userDetail(let user): UserDetailView(user: user)
+            case .settings: SettingsView()
+            }
+        }
+}
+```
+
+---
+
+## Testing
+
+### Framework Stack
+
+| Tool | Purpose |
+|------|---------|
+| Swift Testing | Modern test framework |
+| XCTest | Traditional test framework |
+| XCUITest | UI automation |
+| swift-snapshot-testing | Snapshot testing |
+
+### Test Structure
+
+```swift
+@Suite("UserService")
+struct UserServiceTests {
+    @Test("creates user with valid input")
+    func createUserValid() async throws {
+        let user = try await sut.create(request)
+        #expect(user.name == "Alice")
+    }
+
+    @Test("validates email format", arguments: ["invalid", "", "@missing"])
+    func invalidEmails(email: String) async {
+        await #expect(throws: ValidationError.invalidEmail) {
+            try await sut.create(CreateUserRequest(name: "Test", email: email))
+        }
+    }
+}
+```
+
+---
+
+## Performance
+
+### Key Patterns
+
+- Profile with Instruments before optimizing
+- Value types for stack allocation and no ARC overhead
+- `lazy` collections for chained operations on large datasets
+- `Set` for membership tests, `Dictionary` for keyed access
+- `reserveCapacity` for collections with known sizes
+- `[weak self]` in closures to prevent retain cycles
+- `LazyVStack`/`LazyHStack` in SwiftUI for large lists
+
+---
+
+## Tooling
+
+### Essential Stack
+
+| Tool | Purpose |
+|------|---------|
+| Swift Package Manager | Dependency management and build |
+| SwiftLint | Static analysis and style |
+| swift-format | Code formatting |
+| Instruments | Profiling and performance |
+| os.Logger | Unified logging |
+
+### CI Essentials
+
+```bash
+swift build                  # Build
+swift test --parallel        # Run tests
+swiftlint --strict           # Static analysis
+```
+
+---
+
+## Definition of Done
+
+A Swift feature is complete when:
+
+- [ ] Compiles with zero warnings
+- [ ] All tests pass (unit + UI)
+- [ ] No force-unwraps without documented justification
+- [ ] No `var` where `let` suffices
+- [ ] Proper access control applied
+- [ ] Structured concurrency used (no raw GCD in new code)
+- [ ] SwiftLint reports zero violations
+- [ ] No retain cycles verified
+- [ ] Accessibility labels on interactive UI
+- [ ] Code reviewed and approved


### PR DESCRIPTION
## Summary

- Adds principal-level Swift engineering template with 8 rule files and CLAUDE.md
- Covers structured concurrency (async/await, actors, TaskGroup), SwiftUI (state management, Observation framework, navigation), protocol-oriented design, optionals, error handling, Swift Testing framework, Instruments profiling, and SPM/SwiftLint tooling
- Registered in index.js, tests updated (94 passing), README updated

## Test plan

- [x] All 94 tests pass (`npx vitest run`)
- [ ] Manual: `node bin/cli.js swift-expert --dry-run` shows all 8 rule files
- [ ] Manual: verify rule files install correctly with `node bin/cli.js swift-expert`

🤖 Generated with [Claude Code](https://claude.com/claude-code)