### PR TITLE
fix(cursor): copy legacy .cursorrules/ to .cursor/rules/ before removal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -886,6 +886,23 @@ async function install(targetDir, templates, dryRun = false, force = false, ides
         );
 
         if (shouldCleanup) {
+          // Copy legacy rule files to .cursor/rules/ before removing (don't overwrite existing)
+          const legacyEntries = fs.readdirSync(legacyDir, { withFileTypes: true });
+          let copiedCount = 0;
+          for (const entry of legacyEntries) {
+            if (!entry.isFile()) continue;
+            const name = entry.name;
+            const legacyPath = path.join(legacyDir, name);
+            const destPath = path.join(cursorRulesDir, name);
+            if (!fs.existsSync(destPath)) {
+              fs.copyFileSync(legacyPath, destPath);
+              console.log(colors.dim(`  ${colors.green('[migrated]')} ${name} → ${CURSOR_RULES_DIR}/`));
+              copiedCount++;
+            }
+          }
+          if (copiedCount > 0) {
+            console.log(colors.green(`  ✓ Migrated ${copiedCount} file(s) from ${LEGACY_CURSORRULES_DIR}/ to ${CURSOR_RULES_DIR}/.`));
+          }
           fs.rmSync(legacyDir, { recursive: true });
           console.log(colors.green(`  ✓ Removed deprecated ${LEGACY_CURSORRULES_DIR}/ directory.`));
         } else {


### PR DESCRIPTION
## Problem
The helper for deprecated `.cursorrules/` deleted the old directory without copying its contents to `.cursor/rules/`, so custom rules were lost when the user confirmed cleanup.

## Solution
- Before removing `.cursorrules/`, copy all files from it into `.cursor/rules/`.
- Do not overwrite existing files in `.cursor/rules/` (existing rules win).
- Log each migrated file and a summary.

## Tests
- **Copy then remove**: Legacy `old-rule.md` and `custom-guide.md` are copied to `.cursor/rules/` and legacy dir is removed.
- **No overwrite**: If a file with the same name already exists in `.cursor/rules/`, it is left unchanged.