### PR TITLE
feat: skill-loader for universal skill.yaml format

### DIFF
--- a/src/core/skill-loader.js
+++ b/src/core/skill-loader.js
@@ -1,0 +1,303 @@
+/**
+ * skill-loader.js
+ *
+ * Loads and validates agent skill packs from the universal skill format.
+ * A skill lives in a directory containing:
+ *   - skill.yaml        (manifest)
+ *   - prompts/
+ *       minimal.md      (~800 tokens: core identity only)
+ *       standard.md     (~3200 tokens: full behavioral prompt)
+ *       comprehensive.md (~8000 tokens: includes examples)
+ *   - tools/            (optional YAML tool definitions)
+ *   - output_schemas/   (optional output schema definitions)
+ *   - tests/            (optional test cases)
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const REQUIRED_MANIFEST_FIELDS = ['name', 'version', 'category', 'description', 'context_budget'];
+
+const SEMVER_RE = /^\d+\.\d+\.\d+/;
+
+const TIER_ORDER = ['minimal', 'standard', 'comprehensive'];
+
+// ============================================================================
+// YAML parser (minimal — handles the subset used in skill.yaml)
+// ============================================================================
+
+/**
+ * Parse a minimal subset of YAML sufficient for skill manifests.
+ * Handles: strings, numbers, booleans, arrays (- item), nested objects (key:\n  child:).
+ * Does NOT handle: anchors, multi-line strings, quoted strings with colons.
+ */
+export function parseYaml(text) {
+  const lines = text.split('\n');
+  return parseBlock(lines, 0, 0).value;
+}
+
+function parseBlock(lines, startIndex, baseIndent) {
+  const result = {};
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trimStart();
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith('#')) {
+      i++;
+      continue;
+    }
+
+    const indent = line.length - trimmed.length;
+
+    // Dedent signals end of this block
+    if (indent < baseIndent) {
+      break;
+    }
+
+    // Array item
+    if (trimmed.startsWith('- ')) {
+      // Arrays are handled by the parent; return early
+      break;
+    }
+
+    // Key: value pair
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) {
+      i++;
+      continue;
+    }
+
+    const key = trimmed.slice(0, colonIdx).trim();
+    const rest = trimmed.slice(colonIdx + 1).trimStart();
+
+    if (rest === '' || rest === '\r') {
+      // Value is a nested block or array on next lines
+      i++;
+      if (i < lines.length) {
+        const nextTrimmed = lines[i].trimStart();
+        if (nextTrimmed.startsWith('- ')) {
+          // Array
+          const arr = [];
+          while (i < lines.length) {
+            const l = lines[i];
+            const t = l.trimStart();
+            if (!t || t.startsWith('#')) { i++; continue; }
+            if (!t.startsWith('- ')) break;
+            const itemIndent = l.length - t.length;
+            if (itemIndent < indent) break;
+            arr.push(parseScalar(t.slice(2).trim()));
+            i++;
+          }
+          result[key] = arr;
+        } else {
+          // Nested object
+          const child = parseBlock(lines, i, indent + 1);
+          result[key] = child.value;
+          i = child.nextIndex;
+        }
+      }
+    } else {
+      result[key] = parseScalar(rest);
+      i++;
+    }
+  }
+
+  return { value: result, nextIndex: i };
+}
+
+function parseScalar(str) {
+  const s = str.trim();
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  if (s === 'null' || s === '~') return null;
+  const n = Number(s);
+  if (!Number.isNaN(n) && s !== '') return n;
+  // Strip surrounding quotes
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+// ============================================================================
+// Manifest validation
+// ============================================================================
+
+/**
+ * Validate a parsed skill manifest object.
+ * @param {object} manifest
+ * @returns {string[]} Array of error messages (empty = valid)
+ */
+export function validateManifest(manifest) {
+  const errors = [];
+
+  // Required fields
+  for (const field of REQUIRED_MANIFEST_FIELDS) {
+    if (manifest[field] === undefined || manifest[field] === null) {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+
+  // name must be a string
+  if (manifest.name !== undefined && typeof manifest.name !== 'string') {
+    errors.push('Field "name" must be a string');
+  }
+
+  // version must match semver
+  if (manifest.version !== undefined) {
+    if (typeof manifest.version !== 'string' || !SEMVER_RE.test(manifest.version)) {
+      errors.push('Field "version" must be a valid semver string (e.g. 1.0.0)');
+    }
+  }
+
+  // description.short is required
+  if (manifest.description !== undefined) {
+    if (typeof manifest.description !== 'object' || !manifest.description.short) {
+      errors.push('Field "description.short" is required');
+    }
+  }
+
+  // context_budget fields must be positive numbers
+  if (manifest.context_budget !== undefined && typeof manifest.context_budget === 'object') {
+    for (const tier of ['minimal', 'standard', 'comprehensive']) {
+      const val = manifest.context_budget[tier];
+      if (val === undefined) {
+        errors.push(`Missing required field: context_budget.${tier}`);
+      } else if (typeof val !== 'number' || val <= 0) {
+        errors.push(`Field "context_budget.${tier}" must be a positive number`);
+      }
+    }
+  }
+
+  // conflicts_with must not overlap with composable_with.recommended
+  if (manifest.conflicts_with && manifest.composable_with?.recommended) {
+    const conflicts = new Set(manifest.conflicts_with);
+    const overlapping = manifest.composable_with.recommended.filter((s) => conflicts.has(s));
+    if (overlapping.length > 0) {
+      errors.push(
+        `Skills cannot both conflict with and be recommended alongside: ${overlapping.join(', ')}`
+      );
+    }
+  }
+
+  return errors;
+}
+
+// ============================================================================
+// Tool loader
+// ============================================================================
+
+function loadTools(skillDir) {
+  const toolsDir = path.join(skillDir, 'tools');
+  if (!fs.existsSync(toolsDir)) return [];
+
+  const tools = [];
+  for (const file of fs.readdirSync(toolsDir)) {
+    if (!file.endsWith('.yaml') && !file.endsWith('.yml')) continue;
+    const raw = fs.readFileSync(path.join(toolsDir, file), 'utf8');
+    const tool = parseYaml(raw);
+    tools.push(tool);
+  }
+  return tools;
+}
+
+// ============================================================================
+// Skill loader
+// ============================================================================
+
+/**
+ * Load a skill from a directory.
+ *
+ * @param {string} skillDir - Path to the skill directory
+ * @param {object} [options]
+ * @param {'minimal'|'standard'|'comprehensive'} [options.tier='standard'] - Prompt tier to use
+ * @returns {Promise<SkillPack>}
+ *
+ * @typedef {object} SkillPack
+ * @property {string} name
+ * @property {string} version
+ * @property {string} category
+ * @property {string[]} tags
+ * @property {object} description
+ * @property {object} context_budget
+ * @property {{ minimal: string, standard: string, comprehensive: string }} prompts
+ * @property {string} systemPrompt - The prompt for the requested tier (with fallback)
+ * @property {'minimal'|'standard'|'comprehensive'} tierUsed - Actual tier used (may differ due to fallback)
+ * @property {object[]} tools
+ */
+export async function loadSkill(skillDir, options = {}) {
+  const { tier = 'standard' } = options;
+
+  // Verify directory exists
+  if (!fs.existsSync(skillDir)) {
+    throw new Error(`Skill directory not found: ${skillDir}`);
+  }
+
+  // Load and parse manifest
+  const manifestPath = path.join(skillDir, 'skill.yaml');
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`skill.yaml not found in ${skillDir}`);
+  }
+
+  const manifestRaw = fs.readFileSync(manifestPath, 'utf8');
+  const manifest = parseYaml(manifestRaw);
+
+  const errors = validateManifest(manifest);
+  if (errors.length > 0) {
+    throw new Error(`Invalid skill manifest in ${skillDir}:\n  ${errors.join('\n  ')}`);
+  }
+
+  // Load prompt tiers
+  const promptsDir = path.join(skillDir, 'prompts');
+  const prompts = {};
+  for (const t of TIER_ORDER) {
+    const filePath = path.join(promptsDir, `${t}.md`);
+    if (fs.existsSync(filePath)) {
+      prompts[t] = fs.readFileSync(filePath, 'utf8');
+    }
+  }
+
+  // Resolve tier with fallback
+  let tierUsed = tier;
+  let systemPrompt = prompts[tier];
+
+  if (!systemPrompt) {
+    // Fall back through tier order toward standard
+    const fallbackOrder =
+      tier === 'minimal' ? ['standard', 'comprehensive'] : ['standard', 'minimal', 'comprehensive'];
+    for (const fallback of fallbackOrder) {
+      if (prompts[fallback]) {
+        tierUsed = fallback;
+        systemPrompt = prompts[fallback];
+        break;
+      }
+    }
+  }
+
+  // Load tools
+  const tools = loadTools(skillDir);
+
+  return {
+    name: manifest.name,
+    version: manifest.version,
+    category: manifest.category,
+    tags: manifest.tags || [],
+    description: manifest.description,
+    context_budget: manifest.context_budget,
+    composable_with: manifest.composable_with || {},
+    conflicts_with: manifest.conflicts_with || [],
+    requires_tools: manifest.requires_tools || false,
+    requires_memory: manifest.requires_memory || false,
+    prompts,
+    systemPrompt: systemPrompt || '',
+    tierUsed,
+    tools,
+  };
+}

--- a/src/core/skill-loader.test.js
+++ b/src/core/skill-loader.test.js
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { loadSkill, validateManifest, REQUIRED_MANIFEST_FIELDS } from './skill-loader.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const VALID_MANIFEST = {
+  name: 'test-skill',
+  version: '1.0.0',
+  category: 'engineering',
+  tags: ['testing'],
+  description: {
+    short: 'A test skill for unit testing',
+    long: 'A comprehensive test skill used for validating the skill-loader module.',
+  },
+  context_budget: {
+    minimal: 800,
+    standard: 3200,
+    comprehensive: 8000,
+  },
+};
+
+function writeYaml(obj) {
+  // Minimal YAML serializer for test fixtures (handles nested objects + arrays)
+  function serialize(val, indent = 0) {
+    const pad = '  '.repeat(indent);
+    if (Array.isArray(val)) {
+      return val.map((v) => `${pad}- ${typeof v === 'object' ? '\n' + serialize(v, indent + 1) : v}`).join('\n');
+    }
+    if (typeof val === 'object' && val !== null) {
+      return Object.entries(val)
+        .map(([k, v]) => {
+          if (typeof v === 'object' && !Array.isArray(v)) {
+            return `${pad}${k}:\n${serialize(v, indent + 1)}`;
+          }
+          if (Array.isArray(v)) {
+            return `${pad}${k}:\n${serialize(v, indent + 1)}`;
+          }
+          return `${pad}${k}: ${v}`;
+        })
+        .join('\n');
+    }
+    return String(val);
+  }
+  return serialize(obj);
+}
+
+function createSkillFixture(dir, manifest = VALID_MANIFEST, prompts = {}) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(path.join(dir, 'prompts'), { recursive: true });
+
+  const yamlContent = writeYaml(manifest);
+  fs.writeFileSync(path.join(dir, 'skill.yaml'), yamlContent);
+
+  const defaultPrompts = {
+    'minimal.md': '# Test Skill (Minimal)\n\nCore identity only.',
+    'standard.md': '# Test Skill (Standard)\n\nFull behavioral prompt.',
+    'comprehensive.md': '# Test Skill (Comprehensive)\n\nFull prompt with examples.',
+  };
+  const allPrompts = { ...defaultPrompts, ...prompts };
+
+  for (const [filename, content] of Object.entries(allPrompts)) {
+    if (content !== null) {
+      fs.writeFileSync(path.join(dir, 'prompts', filename), content);
+    }
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('REQUIRED_MANIFEST_FIELDS', () => {
+  it('includes all required top-level fields', () => {
+    expect(REQUIRED_MANIFEST_FIELDS).toEqual(
+      expect.arrayContaining(['name', 'version', 'category', 'description', 'context_budget'])
+    );
+  });
+});
+
+describe('validateManifest', () => {
+  it('returns no errors for a valid manifest', () => {
+    const errors = validateManifest(VALID_MANIFEST);
+    expect(errors).toEqual([]);
+  });
+
+  it('returns errors for missing required fields', () => {
+    const errors = validateManifest({});
+    for (const field of REQUIRED_MANIFEST_FIELDS) {
+      expect(errors).toEqual(expect.arrayContaining([expect.stringContaining(field)]));
+    }
+  });
+
+  it('returns error when name is not a string', () => {
+    const errors = validateManifest({ ...VALID_MANIFEST, name: 123 });
+    expect(errors).toEqual(expect.arrayContaining([expect.stringContaining('name')]));
+  });
+
+  it('returns error when version is not semver', () => {
+    const errors = validateManifest({ ...VALID_MANIFEST, version: 'not-semver' });
+    expect(errors).toEqual(expect.arrayContaining([expect.stringContaining('version')]));
+  });
+
+  it('returns error when description.short is missing', () => {
+    const errors = validateManifest({
+      ...VALID_MANIFEST,
+      description: { long: 'only long' },
+    });
+    expect(errors).toEqual(expect.arrayContaining([expect.stringContaining('description.short')]));
+  });
+
+  it('returns error when context_budget.minimal is missing', () => {
+    const errors = validateManifest({
+      ...VALID_MANIFEST,
+      context_budget: { standard: 3200, comprehensive: 8000 },
+    });
+    expect(errors).toEqual(expect.arrayContaining([expect.stringContaining('context_budget.minimal')]));
+  });
+
+  it('returns error when context_budget values are not positive numbers', () => {
+    const errors = validateManifest({
+      ...VALID_MANIFEST,
+      context_budget: { minimal: -1, standard: 0, comprehensive: 'big' },
+    });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('returns error when conflicts_with and composable_with.recommended overlap', () => {
+    const errors = validateManifest({
+      ...VALID_MANIFEST,
+      composable_with: { recommended: ['foo'] },
+      conflicts_with: ['foo'],
+    });
+    expect(errors).toEqual(expect.arrayContaining([expect.stringContaining('conflict')]));
+  });
+});
+
+describe('loadSkill', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-loader-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('loads a valid skill and returns structured result', async () => {
+    const skillDir = path.join(tmpDir, 'test-skill');
+    createSkillFixture(skillDir);
+
+    const skill = await loadSkill(skillDir);
+
+    expect(skill.name).toBe('test-skill');
+    expect(skill.version).toBe('1.0.0');
+    expect(skill.category).toBe('engineering');
+    expect(skill.description.short).toBe('A test skill for unit testing');
+  });
+
+  it('loads all three prompt tiers', async () => {
+    const skillDir = path.join(tmpDir, 'test-skill');
+    createSkillFixture(skillDir);
+
+    const skill = await loadSkill(skillDir);
+
+    expect(skill.prompts.minimal).toContain('Minimal');
+    expect(skill.prompts.standard).toContain('Standard');
+    expect(skill.prompts.comprehensive).toContain('Comprehensive');
+  });
+
+  it('returns the prompt for a requested tier', async () => {
+    const skillDir = path.join(tmpDir, 'test-skill');
+    createSkillFixture(skillDir);
+
+    const skill = await loadSkill(skillDir, { tier: 'minimal' });
+
+    expect(skill.systemPrompt).toContain('Minimal');
+  });
+
+  it('defaults to standard tier when no tier specified', async () => {
+    const skillDir = path.join(tmpDir, 'test-skill');
+    createSkillFixture(skillDir);
+
+    const skill = await loadSkill(skillDir);
+
+    expect(skill.systemPrompt).toContain('Standard');
+  });
+
+  it('falls back to standard when minimal tier file is missing', async () => {
+    const skillDir = path.join(tmpDir, 'test-skill');
+    createSkillFixture(skillDir, VALID_MANIFEST, { 'minimal.md': null });
+
+    const skill = await loadSkill(skillDir, { tier: 'minimal' });
+
+    expect(skill.systemPrompt).toContain('Standard');
+    expect(skill.tierUsed).toBe('standard');
+  });
+
+  it('throws when skill directory does not exist', async () => {
+    await expect(loadSkill('/nonexistent/path')).rejects.toThrow(/not found|does not exist/i);
+  });
+
+  it('throws when skill.yaml is missing', async () => {
+    const skillDir = path.join(tmpDir, 'no-manifest');
+    fs.mkdirSync(skillDir);
+
+    await expect(loadSkill(skillDir)).rejects.toThrow(/skill\.yaml/i);
+  });
+
+  it('throws when skill.yaml has validation errors', async () => {
+    const skillDir = path.join(tmpDir, 'bad-manifest');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'skill.yaml'), 'name: 123\nversion: bad');
+
+    await expect(loadSkill(skillDir)).rejects.toThrow(/invalid|validation/i);
+  });
+
+  it('includes tools array (empty when no tools/ dir)', async () => {
+    const skillDir = path.join(tmpDir, 'test-skill');
+    createSkillFixture(skillDir);
+
+    const skill = await loadSkill(skillDir);
+
+    expect(Array.isArray(skill.tools)).toBe(true);
+    expect(skill.tools).toHaveLength(0);
+  });
+
+  it('includes the context_budget from manifest', async () => {
+    const skillDir = path.join(tmpDir, 'test-skill');
+    createSkillFixture(skillDir);
+
+    const skill = await loadSkill(skillDir);
+
+    expect(skill.context_budget.minimal).toBe(800);
+    expect(skill.context_budget.standard).toBe(3200);
+    expect(skill.context_budget.comprehensive).toBe(8000);
+  });
+
+  it('loads tools from tools/ directory when present', async () => {
+    const skillDir = path.join(tmpDir, 'skill-with-tools');
+    createSkillFixture(skillDir);
+    fs.mkdirSync(path.join(skillDir, 'tools'), { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, 'tools', 'web_search.yaml'),
+      'name: web_search\ndescription: Search the web\nparameters:\n  query:\n    type: string\n    required: true\n'
+    );
+
+    const skill = await loadSkill(skillDir);
+
+    expect(skill.tools).toHaveLength(1);
+    expect(skill.tools[0].name).toBe('web_search');
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 1 of #91 — foundational module for the Universal Agent Skills Framework.

- `src/core/skill-loader.js` — load and validate skill packs from `skill.yaml` + tiered prompts
- `src/core/skill-loader.test.js` — 20 TDD tests (written before implementation)

### What it adds

- **`parseYaml()`** — zero-dependency minimal YAML parser (covers the subset used in manifests)
- **`validateManifest()`** — validates required fields, semver, positive budget values, and conflict/composability integrity
- **`loadSkill(dir, { tier })`** — returns a `SkillPack`:
  - All three prompt tiers loaded (`minimal`, `standard`, `comprehensive`)
  - `systemPrompt` for the requested tier with fallback to `standard` when a tier file is missing
  - `tierUsed` to indicate which tier was actually served
  - `tools[]` from `tools/*.yaml` files

### Skill manifest shape (`skill.yaml`)

```yaml
name: strategic-negotiator
version: 1.0.0
category: business
tags: [negotiation, contracts]
description:
  short: "Game theory and negotiation for M&A, contracts, and deals"
  long: "..."
context_budget:
  minimal: 800
  standard: 3200
  comprehensive: 8000
composable_with:
  recommended: [legal-compliance, financial-analysis]
conflicts_with: []
requires_tools: false
requires_memory: false
```

## Test plan

- [x] `validateManifest` — required fields, type checks, semver, budget tiers, conflict overlap
- [x] `loadSkill` — loads manifest, all tiers, tier selection, fallback, missing dir/yaml, invalid manifest, tools
- [x] All 134 tests pass (20 new + 114 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)