### PR TITLE
feat: tool YAML spec + definitions for 4 skill packs

### DIFF
--- a/skills/devops-sre/tools/create_incident.yaml
+++ b/skills/devops-sre/tools/create_incident.yaml
@@ -1,0 +1,34 @@
+name: create_incident
+description: "Create and initialize an incident record with severity classification, on-call notification, and war room setup"
+when_to_use: "When a service degradation or outage is confirmed and needs formal incident tracking; when SLO burn rate crosses the critical threshold"
+parameters:
+  title:
+    type: string
+    description: "Short incident title describing the symptom (not the cause)"
+    required: true
+  severity:
+    type: string
+    description: "Incident severity: SEV1 (complete outage), SEV2 (major degradation), SEV3 (partial degradation), SEV4 (minor issue)"
+    required: true
+  affected_services:
+    type: array
+    description: "List of service names impacted by the incident"
+    required: true
+  initial_hypothesis:
+    type: string
+    description: "Initial hypothesis about the cause (can be updated as investigation proceeds)"
+    default: ""
+returns:
+  type: object
+  description: "Created incident record with ID, war room link, and on-call assignments"
+  properties:
+    incident_id:
+      type: string
+    severity:
+      type: string
+    war_room_url:
+      type: string
+    on_call_notified:
+      type: array
+    created_at:
+      type: string

--- a/skills/devops-sre/tools/query_metrics.yaml
+++ b/skills/devops-sre/tools/query_metrics.yaml
@@ -1,0 +1,34 @@
+name: query_metrics
+description: "Query observability metrics (latency, error rate, throughput, saturation) for a service or endpoint"
+when_to_use: "When investigating an incident, verifying SLO compliance, building error budget calculations, or analyzing service health for a postmortem"
+parameters:
+  service:
+    type: string
+    description: "Service name or identifier to query"
+    required: true
+  metric_type:
+    type: string
+    description: "Metric category: latency, error_rate, throughput, saturation, availability"
+    required: true
+  window:
+    type: string
+    description: "Time window for the query: '5m', '1h', '24h', '7d'"
+    default: 1h
+  percentiles:
+    type: array
+    description: "Latency percentiles to return when metric_type is latency: p50, p95, p99, p999"
+    default: []
+returns:
+  type: object
+  description: "Metric time series with SLO threshold comparison"
+  properties:
+    service:
+      type: string
+    metric_type:
+      type: string
+    data_points:
+      type: array
+    slo_threshold:
+      type: number
+    slo_compliance:
+      type: boolean

--- a/skills/market-intelligence/tools/analyze_sentiment.yaml
+++ b/skills/market-intelligence/tools/analyze_sentiment.yaml
@@ -1,0 +1,28 @@
+name: analyze_sentiment
+description: "Analyze sentiment and signal classification across a set of text sources for a given topic"
+when_to_use: "When aggregating qualitative signals from news, earnings calls, analyst reports, or social data; when classifying whether signals are bullish, bearish, or neutral"
+parameters:
+  topic:
+    type: string
+    description: "The company, sector, or topic to analyze"
+    required: true
+  sources:
+    type: array
+    description: "List of text excerpts or source URLs to analyze"
+    required: true
+  signal_types:
+    type: array
+    description: "Signal categories to detect: earnings, regulatory, macro, competitive, management"
+    default: []
+returns:
+  type: object
+  description: "Sentiment scores and classified signals by category"
+  properties:
+    overall_sentiment:
+      type: string
+    confidence:
+      type: number
+    signals:
+      type: array
+    summary:
+      type: string

--- a/skills/market-intelligence/tools/fetch_market_data.yaml
+++ b/skills/market-intelligence/tools/fetch_market_data.yaml
@@ -1,0 +1,26 @@
+name: fetch_market_data
+description: "Retrieve structured market data for a company, sector, or asset class"
+when_to_use: "When quantitative market data is needed to support an intelligence report; when tracking price, volume, or financial metrics over a time range"
+parameters:
+  ticker_or_query:
+    type: string
+    description: "Stock ticker symbol, sector name, or market query (e.g., 'AAPL', 'semiconductor sector', 'US 10Y yield')"
+    required: true
+  timeframe:
+    type: string
+    description: "Time range for data: '1d', '1w', '1m', '3m', '1y', '5y'"
+    default: 1m
+  metrics:
+    type: array
+    description: "Specific metrics to retrieve: price, volume, market_cap, pe_ratio, revenue_growth"
+    default: []
+returns:
+  type: object
+  description: "Market data points with timestamps and requested metrics"
+  properties:
+    symbol:
+      type: string
+    data_points:
+      type: array
+    metadata:
+      type: object

--- a/skills/research-assistant/tools/document_fetch.yaml
+++ b/skills/research-assistant/tools/document_fetch.yaml
@@ -1,0 +1,24 @@
+name: document_fetch
+description: "Fetch and extract text content from a URL (PDF, web page, or document)"
+when_to_use: "When a specific URL or document needs to be retrieved and read for research; when tracing a claim back to its primary source"
+parameters:
+  url:
+    type: string
+    description: "The URL of the document or web page to fetch"
+    required: true
+  extract_mode:
+    type: string
+    description: "How to extract content: 'full' for complete text, 'summary' for key sections"
+    default: full
+returns:
+  type: object
+  description: "Extracted document content with metadata"
+  properties:
+    content:
+      type: string
+    title:
+      type: string
+    url:
+      type: string
+    fetched_at:
+      type: string

--- a/skills/research-assistant/tools/web_search.yaml
+++ b/skills/research-assistant/tools/web_search.yaml
@@ -1,0 +1,26 @@
+name: web_search
+description: "Search the web for current information on a topic"
+when_to_use: "When the user asks about current events, recent data, or information that may have changed since training cutoff; when primary sources need to be located online"
+parameters:
+  query:
+    type: string
+    description: "The search query, formulated using advanced search operators when appropriate"
+    required: true
+  max_results:
+    type: integer
+    description: "Maximum number of results to return"
+    default: 10
+returns:
+  type: array
+  description: "List of search results with title, url, snippet, and publication date"
+  items:
+    type: object
+    properties:
+      title:
+        type: string
+      url:
+        type: string
+      snippet:
+        type: string
+      published_date:
+        type: string

--- a/skills/strategic-negotiator/tools/scenario_model.yaml
+++ b/skills/strategic-negotiator/tools/scenario_model.yaml
@@ -1,0 +1,28 @@
+name: scenario_model
+description: "Model a negotiation scenario with multiple parties and probability-weighted outcome analysis"
+when_to_use: "When analyzing deal structures, comparing counteroffers, war-gaming negotiation strategies, or calculating expected value across BATNA/ZOPA scenarios"
+parameters:
+  parties:
+    type: array
+    description: "List of negotiating parties, each with known interests, constraints, and estimated BATNA"
+    required: true
+  scenarios:
+    type: array
+    description: "Possible outcome scenarios to evaluate, each with proposed terms"
+    required: true
+  evaluation_criteria:
+    type: array
+    description: "Criteria to score each scenario: expected_value, risk, relationship_impact, precedent"
+    default: []
+returns:
+  type: object
+  description: "Ranked scenarios with expected values, risk assessments, and recommended strategy"
+  properties:
+    ranked_scenarios:
+      type: array
+    recommended_strategy:
+      type: string
+    risk_analysis:
+      type: object
+    walk_away_triggers:
+      type: array


### PR DESCRIPTION
## Summary

- Defines the tool YAML spec format for skill packs: each `tools/*.yaml` file describes a single callable tool with `name`, `description`, `when_to_use`, typed `parameters`, and `returns`
- Adds 7 tool definition files across 4 skill packs: `research-assistant`, `market-intelligence`, `strategic-negotiator`, `devops-sre`
- Extends `skill-loader.test.js` with full schema validation, multi-tool sorting, non-yaml ignore, and real-skill presence checks

## Tool spec format

```yaml
name: tool_name
description: "What the tool does"
when_to_use: "When the agent should invoke it"
parameters:
  param_name:
    type: string | array | object | number | boolean
    description: "..."
    required: true   # omit for optional
    default: value   # for optional params
returns:
  type: object
  description: "..."
  properties:
    field_name:
      type: string
```

## Test plan

- [x] All 234 tests pass
- [x] skill-loader correctly loads tool definitions from `tools/` directory
- [x] Full schema fields (description, when_to_use, parameters, returns) validated
- [x] Multi-tool files sorted by name
- [x] Non-yaml files in `tools/` ignored
- [x] Real skill tool presence verified for all 4 skill packs

🤖 Generated with [Claude Code](https://claude.com/claude-code)