### PR TITLE
docs: update README for skill pack system and 48 skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,11 @@
 ![Cursor](https://img.shields.io/badge/Cursor_IDE-black?style=flat&logo=cursor)
 ![Claude Code](https://img.shields.io/badge/Claude_Code-cc785c?style=flat&logo=anthropic)
 ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-000?style=flat&logo=githubcopilot)
+![Windsurf](https://img.shields.io/badge/Windsurf-0B6FBF?style=flat)
+![LangChain](https://img.shields.io/badge/LangChain-1C3C3C?style=flat)
+![OpenAI Agents](https://img.shields.io/badge/OpenAI_Agents-412991?style=flat)
 
-AI coding assistant templates for Cursor IDE, Claude Code, and GitHub Copilot. Pre-configured rules and guidelines that help AI assistants write better code in your projects.
-
-**Installs (configurable via `--ide`):**
-
-- **`CLAUDE.md`** - Development guide for Claude-based assistants (Claude Code, Cursor with Claude)
-- **`.cursor/rules/`** - Rule files for Cursor IDE
-- **`.github/copilot-instructions.md`** - Instructions for GitHub Copilot
+A library of **48 expert skill packs** for AI coding assistants and agent frameworks. Each skill pack encodes principal-level behavioral guidance in tiered prompts — install them into Cursor, Claude Code, or GitHub Copilot, or compose them into LangChain, CrewAI, and OpenAI Agents SDK pipelines.
 
 > **Disclaimer:** This project is provided for **educational and experimental purposes only**. The author takes no responsibility for any actions, outputs, or consequences resulting from an LLM or AI assistant following these rules. Use at your own risk. Always review AI-generated code before deploying to production.
 
@@ -24,19 +21,19 @@ AI coding assistant templates for Cursor IDE, Claude Code, and GitHub Copilot. P
 No installation required. Run directly with `npx`:
 
 ```bash
-npx @djm204/agent-skills [template-name]
+npx @djm204/agent-skills [skill-name]
 ```
 
 Or install globally:
 
 ```bash
 npm install -g @djm204/agent-skills
-agent-skills [template-name]
+agent-skills [skill-name]
 ```
 
 ## How to Use
 
-### Basic Usage
+### Install into Your IDE
 
 Navigate to your project directory and run:
 
@@ -44,17 +41,21 @@ Navigate to your project directory and run:
 npx @djm204/agent-skills web-frontend
 ```
 
-This installs the template rules in your project directory.
+This installs rule files for all supported IDEs (Cursor, Claude Code, GitHub Copilot):
 
-### Install Multiple Templates
+- **`CLAUDE.md`** — Development guide for Claude Code and Cursor with Claude
+- **`.cursor/rules/`** — Rule files for Cursor IDE (`.mdc` format)
+- **`.github/copilot-instructions.md`** — Instructions for GitHub Copilot
 
-Combine templates for projects that span multiple domains:
+### Install Multiple Skills
+
+Combine skills for projects that span multiple domains:
 
 ```bash
 npx @djm204/agent-skills web-frontend web-backend
 ```
 
-### List All Available Templates
+### List All Available Skills
 
 ```bash
 npx @djm204/agent-skills --list
@@ -70,7 +71,7 @@ npx @djm204/agent-skills web-frontend --dry-run
 
 ### Update to Latest Rules
 
-Re-run with `@latest` to get updated templates:
+Re-run with `@latest` to get updated skills:
 
 ```bash
 npx @djm204/agent-skills@latest web-frontend
@@ -78,7 +79,7 @@ npx @djm204/agent-skills@latest web-frontend
 
 ### Install for Specific IDE
 
-By default, templates install for all supported IDEs (Cursor, Claude, Copilot). Use `--ide` to target specific tools:
+By default, skills install for all supported IDEs. Use `--ide` to target specific tools:
 
 ```bash
 # Install only for Cursor IDE
@@ -94,15 +95,13 @@ npx @djm204/agent-skills web-frontend --ide=codex
 npx @djm204/agent-skills web-frontend --ide=cursor --ide=codex
 ```
 
-### Remove Specific Templates
-
-Remove templates you no longer need while keeping shared rules and other templates:
+### Remove Specific Skills
 
 ```bash
-# Remove a single template
+# Remove a single skill
 npx @djm204/agent-skills --remove web-frontend
 
-# Remove multiple templates
+# Remove multiple skills
 npx @djm204/agent-skills --remove web-frontend web-backend
 
 # Remove from specific IDE only
@@ -114,43 +113,102 @@ npx @djm204/agent-skills --remove web-frontend --yes
 
 ### Reset (Remove Everything)
 
-Remove all installed content (shared rules, templates, generated files):
-
 ```bash
-# Reset all installed content
 npx @djm204/agent-skills --reset
-
-# Reset for specific IDE only
 npx @djm204/agent-skills --reset --ide=cursor
-
-# Skip confirmation prompt
 npx @djm204/agent-skills --reset --yes
-
-# Force remove modified files
 npx @djm204/agent-skills --reset --force
 ```
 
-### CLI Options
+---
+
+## Skill Pack Adapter Mode
+
+Skills can also be composed into AI agent frameworks using the `--adapter` flag. This outputs a prompt file optimized for the target framework instead of installing IDE rule files.
+
+```bash
+npx @djm204/agent-skills <skill-name> --adapter=<adapter> [--tier=<tier>] [--out=<dir>]
+```
+
+### Adapters
+
+| Adapter | Output | Use With |
+|---------|--------|----------|
+| `raw` | Plain markdown prompt | Any LLM, testing |
+| `cursor` | `.cursor/rules/` MDC files | Cursor IDE |
+| `claude-code` | `CLAUDE.md` section | Claude Code |
+| `copilot` | `.github/copilot-instructions.md` section | GitHub Copilot |
+| `openai-agents` | Python `Agent(instructions=...)` snippet | OpenAI Agents SDK |
+| `langchain` | Python `SystemMessagePromptTemplate` | LangChain |
+| `crewai` | Python `Agent(backstory=..., goal=...)` | CrewAI |
+
+### Prompt Tiers
+
+Each skill has three standalone prompt tiers. Choose the tier that fits your context budget:
+
+| Tier | Approx. Tokens | Content |
+|------|---------------|---------|
+| `minimal` | ~700 | Core behavioral rules and anti-patterns only |
+| `standard` | ~2,800 | Principles, patterns, and decision frameworks (default) |
+| `comprehensive` | ~7,500 | Full reference with code examples and tables |
+
+### Examples
+
+```bash
+# Get a raw markdown prompt for use in any LLM
+npx @djm204/agent-skills golang-expert --adapter=raw
+
+# Generate a LangChain agent with minimal token usage
+npx @djm204/agent-skills python-expert --adapter=langchain --tier=minimal
+
+# Generate a CrewAI agent config and write to ./agents/
+npx @djm204/agent-skills strategic-negotiator --adapter=crewai --out=./agents
+
+# Generate an OpenAI Agents SDK snippet
+npx @djm204/agent-skills devops-sre --adapter=openai-agents --tier=standard
+
+# Compose multiple skills together (comma-separated)
+npx @djm204/agent-skills fullstack,testing --adapter=claude-code --tier=comprehensive
+```
+
+### Preview Test Cases
+
+Each skill includes behavioral test cases. Use `--test` to see them without calling an LLM:
+
+```bash
+npx @djm204/agent-skills --test strategic-negotiator
+npx @djm204/agent-skills --test golang-expert
+```
+
+---
+
+## CLI Options
 
 | Option | Description |
 |--------|-------------|
 | `--ide=[name]` | Target IDE: `cursor`, `claude`, or `codex` (can be used multiple times) |
-| `--list`, `-l` | List all available templates |
+| `--adapter=[name]` | Adapter for skill pack mode: `raw`, `cursor`, `claude-code`, `copilot`, `openai-agents`, `langchain`, `crewai` |
+| `--tier=[tier]` | Prompt tier: `minimal`, `standard`, `comprehensive` (default: `standard`) |
+| `--test` | Preview test cases for a skill without calling an LLM |
+| `--skill-dir=[dir]` | Path to a custom skills directory (default: built-in `skills/`) |
+| `--out=[dir]` | Output directory for adapter files (default: current directory) |
+| `--list`, `-l` | List all available skills |
 | `--dry-run` | Preview changes without writing files |
 | `--force`, `-f` | Overwrite/remove even if files were modified |
-| `--remove` | Remove specified templates |
+| `--remove` | Remove specified skills |
 | `--reset` | Remove ALL installed content |
 | `--yes`, `-y` | Skip confirmation prompt (for `--remove` and `--reset`) |
+| `--version`, `-v` | Show version number |
 | `--help`, `-h` | Show help message |
 
 ### Shorthand Aliases
 
-You can use short names instead of full template names for both install and remove (`--remove <alias>`). Run `npx @djm204/agent-skills --list` to see aliases next to each template.
+Use short names instead of full skill names. Run `--list` to see all aliases.
 
 **Languages**
 
-| Alias | Template |
-|-------|----------|
+| Alias | Skill |
+|-------|-------|
 | `js`, `ts`, `javascript`, `typescript` | `javascript-expert` |
 | `go`, `golang` | `golang-expert` |
 | `py`, `python` | `python-expert` |
@@ -164,8 +222,8 @@ You can use short names instead of full template names for both install and remo
 
 **Engineering**
 
-| Alias | Template |
-|-------|----------|
+| Alias | Skill |
+|-------|-------|
 | `frontend`, `fe` | `web-frontend` |
 | `backend`, `api` | `web-backend` |
 | `devops`, `sre` | `devops-sre` |
@@ -180,8 +238,8 @@ You can use short names instead of full template names for both install and remo
 
 **Professional**
 
-| Alias | Template |
-|-------|----------|
+| Alias | Skill |
+|-------|-------|
 | `docs` | `documentation` |
 | `grants` | `grant-writer` |
 | `exec`, `ea` | `executive-assistant` |
@@ -192,8 +250,8 @@ You can use short names instead of full template names for both install and remo
 
 **Business**
 
-| Alias | Template |
-|-------|----------|
+| Alias | Skill |
+|-------|-------|
 | `product` | `product-manager` |
 | `project` | `project-manager` |
 | `compliance`, `regulatory` | `regulatory-sentinel` |
@@ -207,8 +265,8 @@ You can use short names instead of full template names for both install and remo
 
 **Creative**
 
-| Alias | Template |
-|-------|----------|
+| Alias | Skill |
+|-------|-------|
 | `ux`, `uxd`, `design`, `designer` | `ux-designer` |
 | `brand` | `brand-guardian` |
 | `social-media` | `social-media-expert` |
@@ -216,24 +274,26 @@ You can use short names instead of full template names for both install and remo
 | `narrative`, `story` | `narrative-architect` |
 | `trends` | `trend-forecaster` |
 
-**Education & agents**
+**Education & Agents**
 
-| Alias | Template |
-|-------|----------|
+| Alias | Skill |
+|-------|-------|
 | `teach`, `teacher` | `educator` |
 | `agent`, `utility` | `utility-agent` |
 
-## Available Templates (42)
+---
+
+## Available Skills (48)
 
 ### Engineering (13)
 
-| Template | Description |
-|----------|-------------|
+| Skill | Description |
+|-------|-------------|
 | `blockchain` | Smart contracts, DeFi protocols, and Web3 applications (Solidity, Foundry, Viem) |
 | `cli-tools` | Command-line applications and developer tools (Cobra, Commander, Click) |
 | `data-engineering` | Data platforms and pipelines (ETL, data modeling, data quality) |
 | `devops-sre` | DevOps and SRE practices (incident management, observability, SLOs, chaos engineering) |
-| `fullstack` | Full-stack web applications (Next.js, Nuxt, SvelteKit, Remix) |
+| `fullstack` | Full-stack web applications with shared types, API contracts, and E2E testing |
 | `ml-ai` | Machine learning and AI systems (model development, deployment, monitoring) |
 | `mobile` | Mobile applications (React Native, Flutter, native iOS/Android) |
 | `platform-engineering` | Internal developer platforms, infrastructure automation, reliability engineering |
@@ -245,8 +305,8 @@ You can use short names instead of full template names for both install and remo
 
 ### Languages (10)
 
-| Template | Description |
-|----------|-------------|
+| Skill | Description |
+|-------|-------------|
 | `cpp-expert` | Principal-level C++ engineering (modern C++, RAII, concurrency, templates, performance) |
 | `csharp-expert` | Principal-level C# engineering (async, DI, EF Core, ASP.NET Core, testing) |
 | `golang-expert` | Principal-level Go engineering (concurrency, stdlib, production patterns, testing) |
@@ -258,56 +318,65 @@ You can use short names instead of full template names for both install and remo
 | `rust-expert` | Principal-level Rust engineering (ownership, concurrency, unsafe, traits, async) |
 | `swift-expert` | Principal-level Swift engineering (concurrency, SwiftUI, protocols, testing, Apple platforms) |
 
-### Business (8)
+### Business (10)
 
-| Template | Description |
-|----------|-------------|
+| Skill | Description |
+|-------|-------------|
 | `market-intelligence` | Data source aggregation, sentiment analysis, trend detection, and risk signal monitoring |
 | `marketing-expert` | Brand positioning, campaign planning, market analysis, analytics, and growth frameworks |
 | `predictive-maintenance` | Industrial sensor monitoring, failure prediction, maintenance scheduling, and asset lifecycle |
 | `product-manager` | Customer-centric discovery, prioritization, and cross-functional execution |
+| `project-manager` | Planning, risk management, stakeholder alignment, and delivery tracking |
 | `regulatory-sentinel` | Compliance tracking, impact assessment, monitoring, and risk classification |
 | `resource-allocator` | Demand prediction, scheduling optimization, crisis management, and capacity modeling |
 | `strategic-negotiator` | Game theory, deal structuring, scenario modeling, and contract analysis |
-| `supply-chain-harmonizer` | Disruption response, rerouting, inventory rebalancing, and scenario simulation |
+| `supply-chain` | Supply chain operations, procurement, logistics, and vendor management |
+| `supply-chain-harmonizer` | Disruption response, autonomous rerouting, inventory rebalancing, and scenario simulation |
 
 ### Creative (6)
 
-| Template | Description |
-|----------|-------------|
+| Skill | Description |
+|-------|-------------|
 | `brand-guardian` | Brand voice enforcement, visual identity compliance, and content review workflows |
 | `content-creation-expert` | Content strategy, copywriting, SEO content, multimedia production, and editorial ops |
-| `narrative-architect` | World-building, continuity tracking, timeline management, and story bible creation |
+| `narrative-architect` | World-building, continuity tracking, timeline management, and story bible governance |
 | `social-media-expert` | Platform strategy, content planning, audience growth, community management, and analytics |
-| `trend-forecaster` | Signal detection, cultural analysis, trend lifecycle modeling, and forecasting methods |
+| `trend-forecaster` | Signal detection, cultural analysis, trend lifecycle modeling, and color/material forecasting |
 | `ux-designer` | User research, interaction design, design systems, accessibility, and emotional design |
 
-### Professional (4)
+### Professional (7)
 
-| Template | Description |
-|----------|-------------|
+| Skill | Description |
+|-------|-------------|
 | `documentation` | Technical documentation standards (READMEs, API docs, ADRs, code comments) |
+| `executive-assistant` | Scheduling, correspondence, meeting management, and executive workflow optimization |
+| `grant-writer` | Proposal strategy, narrative development, budget justification, and funder research |
 | `knowledge-synthesis` | Document ingestion, knowledge graphs, search/retrieval, summarization, and research workflows |
 | `life-logistics` | Scheduling optimization, bill negotiation, insurance comparison, and vendor research |
+| `research-assistant` | Literature review, source evaluation, citation management, and synthesis reporting |
 | `wellness-orchestrator` | Unified wellness planning across fitness, nutrition, sleep, and mental wellness |
 
 ### Education (1)
 
-| Template | Description |
-|----------|-------------|
+| Skill | Description |
+|-------|-------------|
 | `educator` | Evidence-based teaching, learning retention, gamification, and assessment design |
 
 ### Agents (1)
 
-| Template | Description |
-|----------|-------------|
+| Skill | Description |
+|-------|-------------|
 | `utility-agent` | AI agent utilities with context management and hallucination prevention |
+
+---
 
 ## What Gets Installed
 
-### Shared Rules (Always Included)
+### IDE Mode (default)
 
-Every template installation includes these foundational rules:
+Every skill installation includes foundational shared rules plus domain-specific rules:
+
+**Shared (always included):**
 
 | File | Description |
 |------|-------------|
@@ -317,29 +386,36 @@ Every template installation includes these foundational rules:
 | `git-workflow.mdc` | Commits, branches, PRs, safety protocols |
 | `communication.mdc` | Direct, objective, professional communication |
 
-### Template-Specific Rules
+**Skill-specific rules** — each skill adds domain-focused `.mdc` rule files. For example, `web-frontend` adds:
 
-Each template adds domain-specific rules. For example, `web-frontend` includes:
+- `accessibility.mdc` — WCAG compliance, ARIA patterns
+- `component-patterns.mdc` — React/Vue/Svelte best practices
+- `performance.mdc` — Core Web Vitals, optimization
+- `state-management.mdc` — State patterns, data flow
+- `styling.mdc` — CSS architecture, design systems
+- `testing.mdc` — Unit, integration, E2E testing
 
-- `accessibility.mdc` - WCAG compliance, ARIA patterns
-- `component-patterns.mdc` - React/Vue/Svelte best practices
-- `performance.mdc` - Core Web Vitals, optimization
-- `state-management.mdc` - State patterns, data flow
-- `styling.mdc` - CSS architecture, design systems
-- `testing.mdc` - Unit, integration, E2E testing
+**Rule file format (`.mdc`):** Every file has YAML front matter with `description` and `alwaysApply`. Shared rules use `alwaysApply: true`; skill-specific rules use `alwaysApply: false` and load when relevant.
 
-### Rule file format (.mdc)
+### Adapter Mode
 
-All rule files use the **`.mdc`** extension (Cursor MDC format). Templates were migrated from `.md` to `.mdc` for better IDE integration and consistent behavior.
+When using `--adapter`, no IDE files are installed. Instead, a single prompt file is generated in the format required by the target framework. Output varies by adapter:
 
-- **Front matter** — Every `.mdc` file has YAML front matter at the top with:
-  - `description`: Short summary of the rule (used by the IDE).
-  - `alwaysApply`: `true` for shared rules (always loaded); `false` for template-specific rules (loaded when relevant).
-- **Short and focused** — Each file covers one topic, with concise sections and clear headings. This keeps rules scannable and gives the AI clear, focused context.
+| Adapter | Output |
+|---------|--------|
+| `raw` | `<skill-name>.md` — plain markdown prompt |
+| `claude-code` | Prompt formatted as a `CLAUDE.md` section |
+| `cursor` | `.cursor/rules/<skill-name>.mdc` |
+| `copilot` | Prompt formatted for `.github/copilot-instructions.md` |
+| `openai-agents` | Python snippet: `Agent(name=..., instructions=...)` |
+| `langchain` | Python snippet: `SystemMessagePromptTemplate.from_template(...)` |
+| `crewai` | Python snippet: `Agent(role=..., goal=..., backstory=...)` |
+
+---
 
 ## File Structure
 
-After running `npx @djm204/agent-skills web-frontend`:
+### After IDE install (`npx @djm204/agent-skills web-frontend`)
 
 ```text
 your-project/
@@ -351,47 +427,55 @@ your-project/
 │       ├── security-fundamentals.mdc           # Shared
 │       ├── git-workflow.mdc                    # Shared
 │       ├── communication.mdc                   # Shared
-│       ├── web-frontend-overview.mdc           # Template-specific
-│       ├── web-frontend-accessibility.mdc      # Template-specific
-│       ├── web-frontend-component-patterns.mdc # Template-specific
-│       ├── web-frontend-performance.mdc        # Template-specific
-│       ├── web-frontend-state-management.mdc   # Template-specific
-│       ├── web-frontend-styling.mdc            # Template-specific
-│       └── web-frontend-testing.mdc            # Template-specific
+│       ├── web-frontend-overview.mdc           # Skill-specific
+│       ├── web-frontend-accessibility.mdc      # Skill-specific
+│       ├── web-frontend-component-patterns.mdc # Skill-specific
+│       ├── web-frontend-performance.mdc        # Skill-specific
+│       ├── web-frontend-state-management.mdc   # Skill-specific
+│       ├── web-frontend-styling.mdc            # Skill-specific
+│       └── web-frontend-testing.mdc            # Skill-specific
 └── .github/
     └── copilot-instructions.md            # Instructions (GitHub Copilot)
 ```
 
-## Customization
+### After adapter install (`npx @djm204/agent-skills golang-expert --adapter=langchain`)
 
-### Add Project-Specific Rules
-
-Create new `.mdc` files in `.cursor/rules/`. Include front matter and keep each file focused on one topic:
-
-```markdown
----
-description: My project API conventions
-alwaysApply: false
----
-
-# My Project Conventions
-
-## API Endpoints
-
-All API calls go through `/lib/api.ts`...
+```text
+your-project/
+└── golang-expert.py                       # LangChain SystemMessagePromptTemplate snippet
 ```
 
-### Modify Existing Rules
+---
 
-Edit any file in `.cursor/rules/` or `CLAUDE.md` directly. Changes take effect immediately.
+## Programmatic API
 
-### Combine with Existing Rules
+Install the package and import from the `/api` subpath:
 
-Templates merge with your existing `.cursor/rules/` directory. Rule files are installed as `.mdc` with YAML front matter (`description`, `alwaysApply`) and short, focused content (one topic per file). Existing files are preserved unless they have the same name.
+```bash
+npm install @djm204/agent-skills
+```
 
-### Migrating from `.cursorrules/`
+```typescript
+import { loadSkill, composeSkills, listSkills, runTestSuite } from '@djm204/agent-skills/api';
 
-If your project uses the older `.cursorrules/` directory, the installer will detect it and offer to clean it up automatically. Cursor now uses `.cursor/rules/` for rule files. Support for `.cursorrules/` will be removed in a future version.
+// Load a single skill at a specific tier
+const skill = await loadSkill('golang-expert', { tier: 'standard' });
+console.log(skill.prompt); // ready-to-use prompt string
+
+// Compose multiple skills (deduplicates shared fragments)
+const composed = await composeSkills(['fullstack', 'testing'], { tier: 'minimal' });
+
+// List all available skills
+const skills = await listSkills();
+
+// Run behavioral test cases against an LLM response
+const suite = await loadTestSuite('golang-expert');
+const results = await runTestSuite(suite, myLlmFn);
+```
+
+TypeScript types are included — no `@types/` package needed.
+
+---
 
 ## Examples
 
@@ -438,32 +522,56 @@ cd my-unity-game
 npx @djm204/agent-skills unity
 ```
 
-### Marketing Team
+### Marketing Team Workspace
 
 ```bash
 cd marketing-workspace
 npx @djm204/agent-skills marketing social-media content-creation
 ```
 
-### Docs and research
+### Docs and Research
 
 ```bash
 npx @djm204/agent-skills docs research
 ```
 
+### LangChain Agent Pipeline
+
+```bash
+# Standard tier for a Go expert agent
+npx @djm204/agent-skills golang-expert --adapter=langchain --out=./agents
+
+# Compose a fullstack + testing specialist (minimal tokens)
+npx @djm204/agent-skills fullstack,testing --adapter=langchain --tier=minimal --out=./agents
+```
+
+### CrewAI Multi-Agent Team
+
+```bash
+npx @djm204/agent-skills product-manager --adapter=crewai --out=./crew
+npx @djm204/agent-skills web-frontend --adapter=crewai --out=./crew
+npx @djm204/agent-skills qa-engineering --adapter=crewai --out=./crew
+```
+
+---
+
 ## Requirements
 
 - **Node.js**: 18.0.0 or higher
-- **Supported IDEs/Tools**:
+- **Supported IDEs/Tools** (IDE mode):
   - Cursor IDE (any version with `.cursor/rules/` support)
   - Claude Code (reads `CLAUDE.md` automatically)
   - GitHub Copilot (reads `.github/copilot-instructions.md`)
+- **Supported Frameworks** (adapter mode):
+  - OpenAI Agents SDK, LangChain, CrewAI, or any LLM via `raw`
+
+---
 
 ## Troubleshooting
 
 ### "Unknown option" or Missing Features
 
-If you're getting errors for options that should exist (like `--reset`), you may have a cached old version:
+If you're getting errors for options that should exist, you may have a cached old version:
 
 ```bash
 # Force latest version (recommended)
@@ -478,119 +586,135 @@ npm cache clean --force
 
 ### Verify Your Version
 
-Check which version you're running:
-
 ```bash
 npx @djm204/agent-skills --version
-```
-
-Output:
-
-```text
-@djm204/agent-skills v1.0.0
-Changelog: https://github.com/djm204/agent-skills/releases/tag/@djm204/agent-skills-v1.0.0
-```
-
-Or use `--help` which also checks for updates:
-
-```bash
-npx @djm204/agent-skills@latest --help
 ```
 
 The CLI will notify you if a newer version is available.
 
 ### Update Global Installation
 
-If installed globally:
-
 ```bash
 npm update -g @djm204/agent-skills
 ```
 
+---
+
 ## How to Contribute
 
-We welcome contributions! Here's how to add new templates or improve existing ones.
+### Adding a New Skill Pack
 
-### Adding a New Template
+Skill packs live in `skills/<skill-name>/` and follow this structure:
 
-1. **Create the template in the appropriate category directory:**
+```text
+skills/your-skill/
+├── skill.yaml                   # Metadata and manifest
+├── prompts/
+│   ├── minimal.md               # ~700 tokens: behavioral rules + anti-patterns
+│   ├── standard.md              # ~2,800 tokens: principles + patterns
+│   └── comprehensive.md         # ~7,500 tokens: full reference with examples
+└── tests/
+    └── test_cases.yaml          # Behavioral test cases
+```
+
+**`skill.yaml` format:**
+
+```yaml
+name: your-skill
+version: 1.0.0
+category: engineering          # engineering | languages | business | creative | professional | education | agents
+tags: [tag1, tag2]
+description:
+  short: "One-line description"
+  long: "Detailed description of what this skill does."
+context_budget:
+  minimal: 700
+  standard: 2800
+  comprehensive: 7500
+composable_with:
+  recommended: [skill-a, skill-b]
+  enhances: [skill-c]
+conflicts_with: []
+requires_tools: false
+requires_memory: false
+```
+
+**Prompt guidelines:**
+- Each tier must be **standalone** (does not depend on other tiers)
+- Prompts are behavioral guidance for AI assistants, not human documentation
+- `minimal.md`: numbered rules + anti-patterns list only
+- `standard.md`: prose-based principles, patterns, decision frameworks (no large code blocks)
+- `comprehensive.md`: full reference with code examples and reference tables
+
+**`test_cases.yaml` format:**
+
+```yaml
+name: your-skill-tests
+skill: your-skill
+version: 1.0.0
+cases:
+  - id: descriptive-id
+    description: What behavior this tests
+    prompt: "A realistic question a developer might ask"
+    expected:
+      contains_any:
+        - keyword1
+        - keyword2
+      not_contains:
+        - bad answer phrase
+      min_length: 80
+    tags: [core, category]
+```
+
+Run `npx @djm204/agent-skills --test your-skill` to preview test cases, and check [`docs/skill-authoring-guide.md`](docs/skill-authoring-guide.md) for the complete authoring reference.
+
+### Adding a Legacy Template (IDE rule files)
+
+1. Create the template in the appropriate category directory:
 
 ```text
 templates/<category>/your-template/
 └── .cursor/
     └── rules/
         ├── overview.mdc          # Scope and core principles (required)
-        ├── topic-one.mdc         # Domain-specific rules
-        ├── topic-two.mdc
-        └── ...
+        ├── topic-one.mdc
+        └── topic-two.mdc
 ```
 
-Categories: `engineering`, `languages`, `creative`, `business`, `professional`, `education`, `agents`
+2. Follow existing patterns — look at `templates/engineering/web-frontend/` for reference.
+3. Add a `category` field to the template entry in `src/index.js`.
 
-2. **Follow the existing patterns:**
-   - Look at `templates/engineering/web-frontend/` or `templates/languages/python-expert/` for reference
-   - Use `.mdc` for all rule files, with YAML front matter (`description`, `alwaysApply`)
-   - Keep each file short and focused on a single topic
-   - Include code examples, not just guidelines
-   - Add "Common Pitfalls" and "Definition of Done" sections where appropriate
+### Testing
 
-3. **Required files:**
-   - `.cursor/rules/overview.mdc` - Scope, core principles, and project structure (with front matter)
-   - Add a `category` field to the template entry in `src/index.js`
-
-### Template Guidelines
-
-**CLAUDE.md should include:**
-
-- Overview and scope
-- Key principles (3-5 bullet points)
-- Technology stack table
-- Code patterns with examples
-- Definition of done checklist
-- Common pitfalls with good/bad examples
-
-**Rule files (.mdc) should:**
-
-- Use the `.mdc` extension with YAML front matter: `description` (short summary) and `alwaysApply` (`true` for shared, `false` for template-specific)
-- Focus on one topic (e.g., testing, security, performance)—short and focused
-- Be actionable with concrete code examples
-- Include both "do" and "don't" examples
-- Stay under ~500 lines for readability
-
-### Improving Existing Templates
-
-1. Fork the repository
-2. Make your changes
-3. Test locally:
-
-   ```bash
-   # From repo root, test installation
-   node bin/cli.js your-template --dry-run
-   ```
-
-4. Submit a PR with:
-   - Clear description of changes
-   - Rationale for additions/modifications
-   - Any new dependencies or requirements
+```bash
+npm test                         # Run all tests (330+)
+npm run validate:rules           # Check template rule sizes (<100 lines)
+node bin/cli.js --list           # List all skills/templates
+node bin/cli.js golang-expert --adapter=raw   # Test adapter output
+node bin/cli.js --test golang-expert          # Preview test cases
+```
 
 ### Shared Rules
 
-The `templates/_shared/` directory contains rules included with every template:
+The `templates/_shared/` directory contains rules included with every IDE installation:
 
-- `core-principles.mdc` - Universal development principles
-- `code-quality.mdc` - Clean code patterns
-- `security-fundamentals.mdc` - Security basics
-- `git-workflow.mdc` - Git conventions
-- `communication.mdc` - AI communication style
+- `core-principles.mdc` — Universal development principles
+- `code-quality.mdc` — Clean code patterns
+- `security-fundamentals.mdc` — Security basics
+- `git-workflow.mdc` — Git conventions
+- `communication.mdc` — AI communication style
 
-Changes to shared rules affect all templates, so be thoughtful with modifications.
+Changes to shared rules affect all templates — be thoughtful with modifications.
 
-### Code Style
+### Submitting a PR
 
-- Use `.mdc` for all rule files (with YAML front matter); use Markdown for README and CLAUDE.md
-- Code examples should be copy-pasteable
-- Prefer concrete examples over abstract guidelines
-- Keep formatting consistent with existing templates; keep rule files short and focused
+1. Fork the repository
+2. Create a branch: `feat/your-skill-name`
+3. Add skill pack files and tests
+4. Run `npm test` and ensure all tests pass
+5. Submit a PR with a clear description of the skill's domain and behavioral focus
+
+---
 
 ## License
 


### PR DESCRIPTION
## Summary

- Updates skill count from 42 → 48 to reflect all newly added skill packs
- Adds **Skill Pack Adapter Mode** section documenting `--adapter`, `--tier`, `--out` flags and all 7 adapters (raw, cursor, claude-code, copilot, openai-agents, langchain, crewai)
- Adds `--test` flag and `--skill-dir` to CLI options table
- Adds **Programmatic API** section with TypeScript usage examples
- Updates **Available Skills** tables: Business (8→10), Professional (4→7)
- Adds Windsurf, LangChain, OpenAI Agents compatibility badges
- Adds adapter output format reference table (what each adapter generates)
- Updates **Contributing** guide with skill pack format (skill.yaml + prompts/ structure)
- Adds LangChain and CrewAI usage examples

## Test plan

- [ ] Verify all 48 skills appear in the table
- [ ] Verify alias tables are complete and match `--list` output
- [ ] Verify adapter examples are accurate
- [ ] Verify programmatic API code snippet matches `src/api/index.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)