### PR TITLE
feat: add mcp_server field to SkillPack

### DIFF
--- a/skills/market-intelligence/skill.yaml
+++ b/skills/market-intelligence/skill.yaml
@@ -30,3 +30,4 @@ conflicts_with: []
 
 requires_tools: true
 requires_memory: false
+mcp_server: "@djm204/mcp-web"

--- a/skills/research-assistant/skill.yaml
+++ b/skills/research-assistant/skill.yaml
@@ -30,3 +30,4 @@ conflicts_with: []
 
 requires_tools: true
 requires_memory: false
+mcp_server: "@djm204/mcp-web"

--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -83,6 +83,8 @@ export interface SkillPack {
   tierUsed: Tier;
   tools: ToolDefinition[];
   output_schemas: OutputSchema[];
+  /** MCP server package name, or null if the skill has no MCP server. */
+  mcp_server: string | null;
 }
 
 // ============================================================================

--- a/src/core/skill-loader.js
+++ b/src/core/skill-loader.js
@@ -328,6 +328,7 @@ export async function loadSkill(skillDir, options = {}) {
     conflicts_with: manifest.conflicts_with || [],
     requires_tools: manifest.requires_tools || false,
     requires_memory: manifest.requires_memory || false,
+    mcp_server: manifest.mcp_server || null,
     prompts,
     systemPrompt: systemPrompt || '',
     tierUsed,

--- a/src/core/skill-loader.test.js
+++ b/src/core/skill-loader.test.js
@@ -446,6 +446,31 @@ describe('loadSkill', () => {
     expect(skill.tools[0].name).toBe('scenario_model');
   });
 
+  // --------------------------------------------------------------------------
+  // mcp_server field
+  // --------------------------------------------------------------------------
+
+  it('passes through mcp_server when present in manifest', async () => {
+    const skillDir = path.join(tmpDir, 'mcp-skill');
+    createSkillFixture(skillDir, {
+      ...VALID_MANIFEST,
+      mcp_server: '@djm204/mcp-web',
+    });
+
+    const skill = await loadSkill(skillDir);
+
+    expect(skill.mcp_server).toBe('@djm204/mcp-web');
+  });
+
+  it('defaults mcp_server to null when absent from manifest', async () => {
+    const skillDir = path.join(tmpDir, 'no-mcp-skill');
+    createSkillFixture(skillDir);
+
+    const skill = await loadSkill(skillDir);
+
+    expect(skill.mcp_server).toBeNull();
+  });
+
   it('ignores non-yaml files in tools/ directory', async () => {
     const skillDir = path.join(tmpDir, 'skill-tools-nonjson');
     createSkillFixture(skillDir);
@@ -495,6 +520,11 @@ describe('real skills with tool definitions', () => {
     const tool = skill.tools.find(t => t.name === 'query_metrics');
     expect(tool).toBeDefined();
     expect(tool.parameters).toBeDefined();
+  });
+
+  it('research-assistant has mcp_server set to @djm204/mcp-web', async () => {
+    const skill = await loadSkill(path.join(SKILLS_DIR, 'research-assistant'));
+    expect(skill.mcp_server).toBe('@djm204/mcp-web');
   });
 
   it('all tool files have required name and description fields', async () => {


### PR DESCRIPTION
## Summary
- Add `mcp_server` field to skill-loader return object (defaults to `null`)
- Add `mcp_server: string | null` to `SkillPack` type definition
- Add `mcp_server: "@djm204/mcp-web"` to `research-assistant` and `market-intelligence` manifests

## Test plan
- [x] 3 new tests: mcp_server present, absent, and real-skill integration
- [x] All 347 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)