### PR TITLE
feat: add security-expert as installable CLI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Use short names instead of full skill names. Run `--list` to see all aliases.
 | `chain`, `web3` | `blockchain` |
 | `platform`, `platform-eng` | `platform-engineering` |
 | `unity` | `unity-dev-expert` |
+| `security`, `sec`, `appsec` | `security-expert` |
 
 **Professional**
 
@@ -351,9 +352,9 @@ Use short names instead of full skill names. Run `--list` to see all aliases.
 
 ---
 
-## Available Skills (44)
+## Available Skills (45)
 
-### Engineering (13)
+### Engineering (14)
 
 | Skill | Description |
 |-------|-------------|
@@ -366,6 +367,7 @@ Use short names instead of full skill names. Run `--list` to see all aliases.
 | `mobile` | Mobile applications (React Native, Flutter, native iOS/Android) |
 | `platform-engineering` | Internal developer platforms, infrastructure automation, reliability engineering |
 | `qa-engineering` | Quality assurance programs for confident, rapid software delivery |
+| `security-expert` | Application security engineering — threat modeling, secure code, OWASP prevention, supply chain security |
 | `testing` | Comprehensive testing practices (TDD, test design, CI/CD integration, performance testing) |
 | `unity-dev-expert` | Unity game development (C#, ECS/DOTS, physics, UI systems, multiplayer, performance) |
 | `web-backend` | Backend APIs and services (REST, GraphQL, microservices) |

--- a/src/index.js
+++ b/src/index.js
@@ -183,6 +183,10 @@ const TEMPLATE_ALIASES = {
   'harmonizer': 'supply-chain-harmonizer',
   'negotiator': 'strategic-negotiator',
   'predictive': 'predictive-maintenance',
+  // Security
+  'security': 'security-expert',
+  'sec': 'security-expert',
+  'appsec': 'security-expert',
   // Creative
   'brand': 'brand-guardian',
   // Agents

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -108,6 +108,7 @@ describe('Constants', () => {
         'python-expert',
         'qa-engineering',
         'regulatory-sentinel',
+        'security-expert',
         'research-assistant',
         'resource-allocator',
         'ruby-expert',

--- a/templates/engineering/security-expert/.cursor/rules/auth.mdc
+++ b/templates/engineering/security-expert/.cursor/rules/auth.mdc
@@ -1,0 +1,41 @@
+---
+description: Authentication and Authorization Patterns
+alwaysApply: false
+---
+
+# Authentication & Authorization
+
+## Password Storage
+
+- Passwords: bcrypt (cost >= 12) or argon2id — never SHA-256, never MD5
+- argon2id is preferred (memory-hard, resists GPU attacks)
+
+## Token Architecture
+
+- Access tokens (JWT): short-lived (15 min max), stateless verification, sent in Authorization header
+- Refresh tokens: long-lived (7-30 days), stored server-side (allows revocation), rotated on each use
+- Store refresh tokens in HTTP-only, Secure, SameSite=Strict cookies
+- Never store tokens in localStorage (XSS-accessible)
+
+## Authorization Checklist
+
+- Auth check happens server-side on every request, not just UI hiding
+- User can only access resources they own (IDOR check: WHERE user_id = $authenticated_user)
+- Role/permission checked at the handler level, not just middleware
+- Admin endpoints on separate routes with additional auth requirements
+- Rate limiting on auth endpoints: 5 attempts / 15 min / IP; exponential backoff
+- Session regenerated after login and privilege escalation
+- Logout invalidates both access and refresh tokens server-side
+
+## OAuth / OIDC
+
+- Always validate the state parameter to prevent CSRF
+- Use PKCE for public clients (SPAs, mobile apps)
+- Validate id_token signature and claims (iss, aud, exp, nonce)
+- Never store access tokens in localStorage; use HTTP-only cookies or in-memory with refresh flow
+
+## MFA
+
+- TOTP or WebAuthn for privileged accounts
+- SMS is last resort (SIM swap attacks)
+- Enforce MFA for admin access and sensitive operations

--- a/templates/engineering/security-expert/.cursor/rules/cryptography.mdc
+++ b/templates/engineering/security-expert/.cursor/rules/cryptography.mdc
@@ -1,0 +1,33 @@
+---
+description: Cryptography Selection and Key Management
+alwaysApply: false
+---
+
+# Cryptography
+
+Don't invent crypto. Use well-reviewed libraries (libsodium, Web Crypto API, crypto module).
+
+## Decision Guide
+
+| Need | Use | Avoid |
+|------|-----|-------|
+| Password hashing | argon2id or bcrypt (cost >= 12) | SHA-*, MD5, scrypt |
+| Symmetric encryption | AES-256-GCM | AES-ECB, AES-CBC without HMAC, DES |
+| Asymmetric encryption | RSA-OAEP (2048+) or X25519 | RSA-PKCS1v1.5, key sizes < 2048 |
+| Signing | Ed25519 or ECDSA P-256 | RSA with SHA-1, HMAC with short keys |
+| Random values | crypto.randomBytes / secrets.token_urlsafe / crypto/rand | Math.random(), random.random() |
+| TLS | 1.2+ only, prefer 1.3 | SSL, TLS 1.0, TLS 1.1 |
+
+## Key Management Rules
+
+- Rotate encryption keys on a schedule (quarterly minimum); support key versioning
+- Separate encryption keys from signing keys
+- Never store keys in the same database as the data they protect
+- Use a secrets manager (Vault, AWS Secrets Manager, GCP Secret Manager) for key storage
+- Derive per-purpose keys using HKDF from a root key — prevents cross-context reuse
+
+## Hashing (non-password)
+
+- SHA-256 minimum for integrity checks
+- Include purpose prefix to prevent cross-context reuse
+- Use HMAC when you need to verify both integrity and authenticity

--- a/templates/engineering/security-expert/.cursor/rules/dependencies.mdc
+++ b/templates/engineering/security-expert/.cursor/rules/dependencies.mdc
@@ -1,0 +1,39 @@
+---
+description: Dependency Security and Supply Chain Hardening
+alwaysApply: false
+---
+
+# Dependency Security
+
+## Before Adding a Dependency
+
+1. Check maintenance: last commit, open issues, release frequency
+2. Check security: known CVEs (npm audit, pip-audit, govulncheck)
+3. Check scope: how many transitive dependencies? Fewer = smaller attack surface
+4. Check permissions: does it need filesystem, network, or native access?
+5. Prefer well-known, widely-audited libraries over obscure alternatives
+
+## Supply Chain Hardening
+
+- Commit lockfiles (package-lock.json, poetry.lock, go.sum)
+- Pin base images for containers: node:20.11.0-alpine, not node:latest
+- Enable dependency review in CI (GitHub Dependency Review Action, Renovate, Dependabot)
+- Generate SBOMs (Software Bill of Materials) for releases
+- Verify package integrity: npm uses integrity hashes in lockfiles; verify signatures where available
+- Rebuild containers on security advisories, not just code changes
+
+## Automated Scanning Pipeline
+
+Run on every PR:
+- Dependency audit (npm audit --audit-level=high / pip-audit / govulncheck)
+- Secret detection (gitleaks, trufflehog)
+- SAST (semgrep, CodeQL)
+- Container scanning (trivy, grype)
+- License compliance check
+
+## Responding to Vulnerabilities
+
+- Patch critical/high CVEs within 48 hours
+- Evaluate medium CVEs within 1 week
+- Document accepted risks with rationale and review date
+- Never suppress audit warnings without a tracking issue

--- a/templates/engineering/security-expert/.cursor/rules/error-handling-logging.mdc
+++ b/templates/engineering/security-expert/.cursor/rules/error-handling-logging.mdc
@@ -1,0 +1,44 @@
+---
+description: Secure Error Handling and Security Logging
+alwaysApply: false
+---
+
+# Secure Error Handling & Logging
+
+## Error Responses
+
+- Return generic error messages to clients: "Authentication failed" not "Password incorrect for user admin@example.com"
+- Never expose stack traces, database errors, or file paths in API responses
+- Use correlation IDs to link generic client errors to detailed server logs
+
+```typescript
+// WRONG — leaks internals
+res.status(500).json({ error: err.message, stack: err.stack, query: err.sql });
+
+// CORRECT — generic response, detailed logging
+const correlationId = crypto.randomUUID();
+logger.error({ err, correlationId, path: req.path, userId: req.user?.id });
+res.status(500).json({ error: 'Internal server error', correlationId });
+```
+
+## Security Event Logging
+
+Log these events with structured data (who, what, when, where, outcome):
+
+- Authentication success/failure (with IP, user-agent)
+- Authorization denial
+- Input validation failure (log the field name, not the value)
+- Privilege escalation (role changes, admin access)
+- Resource access outside normal patterns
+- Configuration changes
+- Dependency vulnerability detections
+
+**Never log:** passwords, tokens, API keys, full credit card numbers, SSNs, or other PII.
+
+## Alerting Triggers
+
+- 5+ failed logins from same IP in 15 minutes
+- Login from new country/device for sensitive accounts
+- Privilege escalation events
+- Spike in 401/403 responses
+- Unexpected outbound network connections

--- a/templates/engineering/security-expert/.cursor/rules/headers-api.mdc
+++ b/templates/engineering/security-expert/.cursor/rules/headers-api.mdc
@@ -1,0 +1,48 @@
+---
+description: Security Headers, CORS, and API Hardening
+alwaysApply: false
+---
+
+# Security Headers & API Hardening
+
+## Recommended HTTP Headers
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.example.com; frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: camera=(), microphone=(), geolocation=()
+```
+
+## CORS Configuration
+
+- Never use Access-Control-Allow-Origin: * for authenticated endpoints
+- Whitelist specific origins; validate against an allowlist, not a regex
+- Set Access-Control-Allow-Credentials: true only when needed; pair with specific origin
+- Limit Access-Control-Allow-Methods to what the API actually uses
+- Set Access-Control-Max-Age to cache preflight responses
+
+## Rate Limiting Strategy
+
+| Endpoint Type | Limit | Window | Action on Exceed |
+|--------------|-------|--------|-----------------|
+| Authentication | 5 requests | 15 min / IP | 429 + exponential backoff |
+| Password reset | 3 requests | 1 hour / account | 429 + silent |
+| Read endpoints | 100 requests | 1 min / token | 429 + Retry-After header |
+| Write endpoints | 20 requests | 1 min / token | 429 + Retry-After header |
+| File upload | 5 requests | 1 hour / user | 429 |
+
+## API Key Security
+
+- Generate with crypto.randomBytes(32) (256 bits entropy)
+- Store hashed (SHA-256 is fine for high-entropy values); show the key once at creation
+- Scope keys to specific endpoints, IP ranges, or rate limits
+- Expire keys on a schedule; support key rotation without downtime
+
+## Secure Defaults
+
+- HTTPS everywhere; redirect HTTP to HTTPS; set HSTS
+- Disable directory listing, debug endpoints, verbose error pages in production
+- Use .env files (gitignored) with .env.example (committed); support rotation without downtime

--- a/templates/engineering/security-expert/.cursor/rules/input-validation.mdc
+++ b/templates/engineering/security-expert/.cursor/rules/input-validation.mdc
@@ -1,0 +1,44 @@
+---
+description: Input Validation and Injection Prevention
+alwaysApply: false
+---
+
+# Input Validation
+
+Client validation is UX. Server validation is security. Always do both.
+
+## Validation Rules
+
+- Use schema validation libraries (Zod, Joi, Pydantic, Go validator) — not manual checks
+- Reject unknown fields; don't silently drop them
+- Bound string lengths, numeric ranges, array sizes
+- Parameterize all database queries unconditionally — no string concatenation, no exceptions
+
+## SQL Injection Prevention
+
+Parameterize every query. No exceptions, no "just this once":
+
+```typescript
+// CORRECT — parameterized
+const user = await db.query('SELECT * FROM users WHERE id = $1', [userId]);
+
+// WRONG — string interpolation
+const user = await db.query(`SELECT * FROM users WHERE id = ${userId}`);
+```
+
+For ORMs, use the query builder's parameterization. If you must write raw SQL, use prepared statements.
+
+## File Upload Security
+
+- Validate content type by reading magic bytes, not the Content-Type header or file extension
+- Enforce file size limits at the web server level
+- Store uploads outside the webroot; serve via a separate handler with Content-Disposition: attachment
+- Rename files with random UUIDs; never use the original filename in storage paths
+- Scan uploaded files for malware in async pipeline if accepting documents
+
+## XSS Prevention
+
+- Use framework auto-escaping (React JSX, Vue templates, Go html/template)
+- Never use dangerouslySetInnerHTML / v-html / {!! !!} with user content
+- Sanitize HTML with allowlist-based libraries (DOMPurify) when rich text is required
+- Set Content-Security-Policy headers to restrict inline scripts

--- a/templates/engineering/security-expert/.cursor/rules/overview.mdc
+++ b/templates/engineering/security-expert/.cursor/rules/overview.mdc
@@ -1,0 +1,37 @@
+---
+description: Application Security Engineering
+alwaysApply: false
+---
+
+# Application Security Engineering
+
+You are a software security engineer. Every input is hostile, every dependency is a liability, and every design decision is a security decision. Shift security left — into design and code, not after deployment.
+
+## Scope
+
+- Threat modeling and secure design
+- Input validation and injection prevention
+- Authentication, authorization, and session management
+- Cryptography selection and key management
+- Dependency security and supply chain hardening
+- Secure error handling and security logging
+- Security headers, CORS, and API hardening
+- Security review and incident response
+
+## Core Principles
+
+1. **Validate at the boundary** — all external input is untrusted; validate shape, type, and range at the system edge using schemas; reject by default, allow by exception
+2. **Defense in depth** — layer validation, authentication, authorization, encryption, and monitoring so one failure does not compromise the system
+3. **Least privilege** — minimum permissions for each component, user, service account, and API token; scope narrowly, revoke when unused
+4. **Fail secure** — deny access on failure; never expose internals in error responses; log details server-side only
+5. **Shift left** — threat model during design; review security in every PR; automate scanning in CI
+
+## Anti-Patterns to Reject
+
+- **Security theater** — controls that look good but reduce no real risk
+- **Secrets in source** — API keys, passwords, or tokens committed to version control or hardcoded
+- **Trusting the client** — relying on frontend validation, hidden fields, or client-side flags for security
+- **Leaking internals** — stack traces, DB errors, or file paths in API responses
+- **Rolling your own crypto** — custom encryption, auth protocols, or session management
+- **Security as afterthought** — "we'll add it later" means "we'll breach first"
+- **Overly broad permissions** — wildcard IAM policies, chmod 777, CORS * on authenticated endpoints

--- a/templates/engineering/security-expert/.cursor/rules/threat-modeling.mdc
+++ b/templates/engineering/security-expert/.cursor/rules/threat-modeling.mdc
@@ -1,0 +1,36 @@
+---
+description: Threat Modeling and Secure Design
+alwaysApply: false
+---
+
+# Threat Modeling
+
+Before writing code, identify what can go wrong. Apply this at feature design, not after deployment.
+
+## STRIDE per Trust Boundary
+
+For each place where trusted meets untrusted (browser <-> API, service <-> database, internal <-> third-party), evaluate:
+
+| Threat | Question | Mitigation Pattern |
+|--------|----------|-------------------|
+| **Spoofing** | Can an attacker pretend to be someone else? | Strong authentication, mutual TLS, API key validation |
+| **Tampering** | Can data be modified in transit or at rest? | HMAC signatures, TLS, checksums, immutable audit logs |
+| **Repudiation** | Can a user deny they performed an action? | Audit logging with tamper-evident storage, signed timestamps |
+| **Information Disclosure** | Can sensitive data leak? | Encryption at rest/transit, field-level access control, log redaction |
+| **Denial of Service** | Can the system be overwhelmed? | Rate limiting, circuit breakers, resource quotas, CDN |
+| **Elevation of Privilege** | Can a user gain unauthorized access? | RBAC/ABAC enforcement, input validation, sandboxing |
+
+## Threat Model Workflow
+
+1. Draw the data flow diagram — actors, processes, data stores, trust boundaries
+2. Enumerate threats using STRIDE for each boundary crossing
+3. Score by impact x likelihood (critical/high/medium/low)
+4. Define mitigations: prevent, detect, or accept (with documented rationale)
+5. Track as security requirements alongside functional requirements
+
+## Assets to Protect
+
+- User PII, payment data, credentials
+- Admin access, API keys, service accounts
+- Business logic (pricing, permissions, feature flags)
+- Infrastructure secrets (database credentials, TLS certs)

--- a/templates/engineering/security-expert/CLAUDE.md
+++ b/templates/engineering/security-expert/CLAUDE.md
@@ -1,0 +1,67 @@
+# Security Expert Development Guide
+
+Principal-level application security engineering — threat modeling, secure coding patterns, OWASP Top 10 prevention, and supply chain security.
+
+---
+
+## Overview
+
+This guide applies to:
+- Threat modeling and secure design reviews
+- Input validation and injection prevention (SQLi, XSS, command injection)
+- Authentication, authorization, and session management
+- Cryptography selection and key management
+- Dependency security and supply chain hardening
+- Secure error handling and security event logging
+- Security headers, CORS, and API hardening
+- Security review checklists and incident response
+
+### Core Principles
+
+1. **Validate at the boundary** — all external input is untrusted; validate shape, type, and range at the system edge using schemas; reject by default
+2. **Defense in depth** — layer validation, authentication, authorization, encryption, and monitoring so one failure does not compromise the system
+3. **Least privilege** — minimum permissions for each component, user, service account, and API token
+4. **Fail secure** — deny access on failure; never expose internals in error responses
+5. **Shift left** — threat model during design; review security in every PR; automate scanning in CI
+
+---
+
+## Security Review Checklist
+
+For every PR touching security-relevant code:
+
+- [ ] All external input validated at the boundary
+- [ ] SQL queries parameterized (no string concatenation)
+- [ ] Auth checks present on every endpoint that needs them
+- [ ] No secrets hardcoded or logged
+- [ ] Error responses don't leak internals
+- [ ] New dependencies reviewed for security and maintenance
+- [ ] Rate limiting applied to new endpoints
+- [ ] Security headers set for new routes
+- [ ] CORS configuration follows allowlist pattern
+- [ ] File uploads validated by content, not extension
+- [ ] Crypto uses approved algorithms
+- [ ] Tests cover the security-relevant behavior
+
+---
+
+## Incident Response
+
+When a security issue is discovered:
+
+1. **Contain** — revoke compromised credentials, block attack vectors, preserve evidence
+2. **Assess** — determine scope: what data was affected, how many users, what access was gained
+3. **Remediate** — fix the vulnerability, rotate all potentially compromised secrets
+4. **Notify** — inform affected users and stakeholders per legal/regulatory requirements
+5. **Review** — blameless post-mortem; update threat model; add regression tests
+
+---
+
+## Anti-Patterns
+
+- Security theater (controls that look good but reduce no real risk)
+- Secrets in source control or hardcoded in application code
+- Client-side-only validation as security
+- Leaking stack traces, DB errors, or file paths in API responses
+- Rolling your own crypto, auth protocol, or session management
+- Overly broad permissions (wildcard IAM, chmod 777, CORS *)

--- a/templates/engineering/security-expert/template.yaml
+++ b/templates/engineering/security-expert/template.yaml
@@ -1,0 +1,12 @@
+name: security-expert
+category: engineering
+description: "Application security engineering — threat modeling, secure code, OWASP prevention, supply chain security"
+rules:
+  - overview.mdc
+  - threat-modeling.mdc
+  - input-validation.mdc
+  - auth.mdc
+  - cryptography.mdc
+  - dependencies.mdc
+  - error-handling-logging.mdc
+  - headers-api.mdc


### PR DESCRIPTION
## Summary

- `security-expert` existed in `skills/` (adapter mode) but had no `templates/` directory, so `npx @djm204/agent-skills security-expert` failed with "Unknown template"
- Creates `templates/engineering/security-expert/` with 8 `.cursor/rules/` files covering threat modeling, input validation, auth, cryptography, dependency security, error handling, and API hardening
- Adds aliases `security`, `sec`, `appsec` to TEMPLATE_ALIASES
- Updates README skill count (44 → 45) and engineering table (13 → 14)

## Test plan

- [x] All 494 tests pass
- [x] `npm run validate:rules` passes (all rule files under 100 lines)
- [x] `node bin/cli.js security-expert --dry-run` installs 8 rule files correctly
- [x] `node bin/cli.js sec --dry-run` resolves alias correctly
- [x] `node bin/cli.js --list` shows security-expert with aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)