### PR TITLE
fix: invoke Hermes skill scripts with bash

### DIFF
--- a/skills/codex-review-loop/SKILL.md
+++ b/skills/codex-review-loop/SKILL.md
@@ -40,7 +40,7 @@ SCRIPT="/absolute/path/to/this/skill/scripts/codex-review-loop.sh"
 If installed in the default profile, the path is usually:
 
 ```bash
-SCRIPT="$HOME/.hermes/skills/github/codex-review-loop/scripts/codex-review-loop.sh"
+SCRIPT="$HOME/.hermes/skills/codex-review-loop/scripts/codex-review-loop.sh"
 ```
 
 Prerequisites:
@@ -52,11 +52,11 @@ Prerequisites:
 
 | Step | Command |
 |------|---------|
-| Detect | `"$SCRIPT" detect --repo OWNER/NAME` |
-| Trigger | `TS=$("$SCRIPT" trigger --repo OWNER/NAME --pr N)` |
-| Poll | `"$SCRIPT" poll --repo OWNER/NAME --pr N --since "$TS"` |
-| Classify fixture | `"$SCRIPT" classify --input fixture.json` |
-| Detect fixture | `"$SCRIPT" detect-classify --input fixture.json` |
+| Detect | `bash "$SCRIPT" detect --repo OWNER/NAME` |
+| Trigger | `TS=$(bash "$SCRIPT" trigger --repo OWNER/NAME --pr N)` |
+| Poll | `bash "$SCRIPT" poll --repo OWNER/NAME --pr N --since "$TS"` |
+| Classify fixture | `bash "$SCRIPT" classify --input fixture.json` |
+| Detect fixture | `bash "$SCRIPT" detect-classify --input fixture.json` |
 
 `detect` returns `available: true | false | "unknown"`. Treat `"unknown"` as trigger-and-observe, not unavailable. Only declare unavailable if normal review polling times out with no Codex response.
 

--- a/skills/resolve-issues/SKILL.md
+++ b/skills/resolve-issues/SKILL.md
@@ -45,7 +45,7 @@ SCRIPT="/absolute/path/to/this/skill/scripts/select-issues.sh"
 Default install path:
 
 ```bash
-SCRIPT="$HOME/.hermes/skills/github/resolve-issues/scripts/select-issues.sh"
+SCRIPT="$HOME/.hermes/skills/resolve-issues/scripts/select-issues.sh"
 ```
 
 ## Argument Shape
@@ -64,7 +64,7 @@ Defaults:
 Forward selection flags to `select-issues.sh`:
 
 ```bash
-"$SCRIPT" [--issue N] [--label L] [--max N] [--repo OWNER/NAME]
+bash "$SCRIPT" [--issue N] [--label L] [--max N] [--repo OWNER/NAME]
 ```
 
 The script returns a JSON array ordered by priority (`priorityRank`: 0 critical, 1 high, 2 medium, 3 low, 99 unprioritized), then newest issue number.


### PR DESCRIPTION
Hermes hub installs do not preserve executable mode for script files, so the instructions should invoke bundled shell scripts via bash.\n\nVerified locally:\n- bash ~/.hermes/skills/codex-review-loop/scripts/codex-review-loop.sh classify --input fixture\n- bash ~/.hermes/skills/resolve-issues/scripts/select-issues.sh --input fixture --max 1